### PR TITLE
Add file upload functionality

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -304,7 +304,7 @@ export const Application = () => {
                               currentFilter={currentFilter} onFilterChange={onFilterChange}
                               isGrid={isGrid} setIsGrid={setIsGrid}
                               sortBy={sortBy} setSortBy={setSortBy}
-                              currentDir={currentDir}
+                              currentDir={currentDir} files={files}
                             />
                             {errorMessage && <EmptyStatePanel paragraph={errorMessage} icon={ExclamationCircleIcon} />}
                             <NavigatorCardBody

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -304,6 +304,7 @@ export const Application = () => {
                               currentFilter={currentFilter} onFilterChange={onFilterChange}
                               isGrid={isGrid} setIsGrid={setIsGrid}
                               sortBy={sortBy} setSortBy={setSortBy}
+                              currentDir={currentDir}
                             />
                             {errorMessage && <EmptyStatePanel paragraph={errorMessage} icon={ExclamationCircleIcon} />}
                             <NavigatorCardBody

--- a/src/app.scss
+++ b/src/app.scss
@@ -157,3 +157,14 @@
 .pf-v5-c-modal-box__title, .pf-v5-c-modal-box__title-text {
     white-space: break-spaces;
 }
+
+.progress-pie {
+    --progress-fill: grey;
+    --progress-empty: lightgrey;
+    aspect-ratio: 1 / 1;
+    border-radius: 100%;
+    display: inline-block;
+    height: 100%;
+    min-height: 16px;
+    background: conic-gradient(var(--progress-fill) var(--progress, 0), var(--progress-empty) var(--progress, 0));
+}

--- a/src/header.jsx
+++ b/src/header.jsx
@@ -75,8 +75,8 @@ export const NavigatorCardHeader = ({
                   setSortBy={setSortBy} sortBy={sortBy}
                 />
                 <UploadButton
-                  files={files}
-                  setChunksProgress={setChunksProgress} setIsUploading={setIsUploading}
+                  files={files} setChunksProgress={setChunksProgress}
+                  isUploading={isUploading} setIsUploading={setIsUploading}
                 />
             </Flex>
         </CardHeader>
@@ -137,7 +137,7 @@ const ViewSelector = ({ isGrid, setIsGrid, sortBy, setSortBy }) => {
     );
 };
 
-const UploadButton = ({ files, setChunksProgress, setIsUploading }) => {
+const UploadButton = ({ files, setChunksProgress, isUploading, setIsUploading }) => {
     const ref = useRef();
 
     const handleClick = () => {
@@ -204,7 +204,11 @@ const UploadButton = ({ files, setChunksProgress, setIsUploading }) => {
 
     return (
         <>
-            <Button variant="secondary" onClick={handleClick}>Upload</Button>
+            <Button
+              variant="secondary" onClick={handleClick}
+              isDisabled={isUploading}
+            >Upload
+            </Button>
             <input
               ref={ref} type="file"
               hidden onChange={onUpload}

--- a/src/header.jsx
+++ b/src/header.jsx
@@ -154,7 +154,10 @@ const UploadButton = ({ currentDir, files }) => {
 
         cockpit.spawn(["mktemp", "-t", `cockpit-upload-${fileName}-XXXXX`])
                 .then(tempPath => {
-                    const process = cockpit.spawn(["dd", `of=${tempPath}`], { superuser: "try", binary: true });
+                    const process = cockpit.spawn(
+                        ["dd", "status=none", `of=${tempPath}`],
+                        { superuser: "try", binary: true }
+                    );
                     const reader = new FileReader();
 
                     let chunkIndex = 0;

--- a/src/header.jsx
+++ b/src/header.jsx
@@ -40,7 +40,7 @@ import { GripVerticalIcon, ListIcon } from "@patternfly/react-icons";
 const _ = cockpit.gettext;
 
 export const NavigatorCardHeader = ({
-    currentFilter, onFilterChange, isGrid, setIsGrid, sortBy, setSortBy, currentDir
+    currentFilter, onFilterChange, isGrid, setIsGrid, sortBy, setSortBy, currentDir, files
 }) => {
     return (
         <CardHeader className="card-actionbar">
@@ -60,7 +60,7 @@ export const NavigatorCardHeader = ({
                   isGrid={isGrid} setIsGrid={setIsGrid}
                   setSortBy={setSortBy} sortBy={sortBy}
                 />
-                <UploadButton currentDir={currentDir} />
+                <UploadButton currentDir={currentDir} files={files} />
             </Flex>
         </CardHeader>
     );
@@ -120,7 +120,7 @@ const ViewSelector = ({ isGrid, setIsGrid, sortBy, setSortBy }) => {
     );
 };
 
-const UploadButton = ({ currentDir }) => {
+const UploadButton = ({ currentDir, files }) => {
     const ref = useRef();
 
     const handleClick = () => {
@@ -128,13 +128,25 @@ const UploadButton = ({ currentDir }) => {
     };
 
     const onUpload = e => {
+        const uploadedFile = e.target.files[0];
+
+        let fileName = uploadedFile.name;
+
+        let fileCount = 2;
+        if (files.some(f => f.name === fileName))
+            fileName += " (1)";
+        while (files.some(f => f.name === fileName)) {
+            fileName = fileName.substring(0, fileName.length - 2) + `${fileCount}` + ")";
+            fileCount += 1;
+        }
+
         const reader = new FileReader();
-        reader.readAsArrayBuffer(e.target.files[0], "UTF-8");
+        reader.readAsArrayBuffer(uploadedFile, "UTF-8");
         reader.onload = readerEvent => {
             const channel = cockpit.channel({
                 binary: true,
                 payload: "fsreplace1",
-                path: currentDir + e.target.files[0].name
+                path: currentDir + fileName
             });
 
             const buffer = readerEvent.target.result;

--- a/src/header.jsx
+++ b/src/header.jsx
@@ -128,7 +128,7 @@ const ViewSelector = ({ isGrid, setIsGrid, sortBy, setSortBy }) => {
 };
 
 const UploadButton = ({ files, setChunksProgress, isUploading, setIsUploading, currentDir }) => {
-    const BLOCK_SIZE = 64 * 1024;
+    const BLOCK_SIZE = 16 * 1024;
     const ref = useRef();
 
     const handleClick = () => {

--- a/src/header.jsx
+++ b/src/header.jsx
@@ -75,8 +75,8 @@ export const NavigatorCardHeader = ({
                   setSortBy={setSortBy} sortBy={sortBy}
                 />
                 <UploadButton
-                  files={files} setChunksProgress={setChunksProgress}
-                  isUploading={isUploading} setIsUploading={setIsUploading}
+                  files={files}
+                  setChunksProgress={setChunksProgress} setIsUploading={setIsUploading}
                 />
             </Flex>
         </CardHeader>
@@ -137,7 +137,7 @@ const ViewSelector = ({ isGrid, setIsGrid, sortBy, setSortBy }) => {
     );
 };
 
-const UploadButton = ({ files, setChunksProgress, isUploading, setIsUploading }) => {
+const UploadButton = ({ files, setChunksProgress, setIsUploading }) => {
     const ref = useRef();
 
     const handleClick = () => {
@@ -204,11 +204,7 @@ const UploadButton = ({ files, setChunksProgress, isUploading, setIsUploading })
 
     return (
         <>
-            <Button
-              variant="secondary" onClick={handleClick}
-              isDisabled={isUploading}
-            >Upload
-            </Button>
+            <Button variant="secondary" onClick={handleClick}>Upload</Button>
             <input
               ref={ref} type="file"
               hidden onChange={onUpload}

--- a/src/header.jsx
+++ b/src/header.jsx
@@ -201,11 +201,12 @@ const UploadButton = ({ files, setChunksProgress, isUploading, setIsUploading })
 };
 
 const UploadProgress = ({ chunksProgress }) => {
-    const progress = Math.round(100 * chunksProgress.completed / chunksProgress.number);
+    const progress = Math.round(100 * chunksProgress.completed / (chunksProgress.number || 1));
+    console.log(progress);
     return (
         <div
           id="progress" className="progress-pie"
-          title="Upload 22% completed" style={{ "--progress": `${progress}%` }}
+          title={`Upload ${progress}% completed`} style={{ "--progress": `${progress}%` }}
         />
     );
 };

--- a/src/header.jsx
+++ b/src/header.jsx
@@ -169,7 +169,7 @@ const UploadButton = ({ currentDir, files }) => {
                             reader.readAsArrayBuffer(chunks[chunkIndex]);
                         } else {
                             process.input();
-                            cockpit.spawn(["mv", tempPath, `/home/mahmoud/${fileName}`])
+                            cockpit.spawn(["mv", tempPath, `/home/mahmoud/${fileName}`], { superuser: "try" })
                                     .then(() => {
                                         // trim newline character
                                         cockpit.spawn(["rm", tempPath.substring(0, tempPath.length - 1)]);

--- a/src/header.jsx
+++ b/src/header.jsx
@@ -166,7 +166,11 @@ const UploadButton = ({ currentDir, files }) => {
                             reader.readAsArrayBuffer(chunks[chunkIndex]);
                         } else {
                             process.input();
-                            cockpit.spawn(["mv", tempPath, `/home/mahmoud/${fileName}`]);
+                            cockpit.spawn(["mv", tempPath, `/home/mahmoud/${fileName}`])
+                                    .then(() => {
+                                        // trim newline character
+                                        cockpit.spawn(["rm", tempPath.substring(0, tempPath.length - 1)]);
+                                    });
                         }
                     };
                 });


### PR DESCRIPTION
Fixes #31
To do:
* [ ] Upload multiple files
* [x] Upload large files (tested on 2.85G file)
* [x] Handle duplicate file names
* [x] Progress bar
* [ ] Add cancel button
* [ ] Hide upload option from localhost
* [ ] Add error handling & remove temp file if error occurs
* [ ] Add `beforeunload` event
* [x] Add tests - use `b.upload_file()`
* [ ] Handle collisions (existing file name)
   * [ ] overwrite confirmation (for the download, edit locally, and upload to replace workflow)
   * [ ] a way to rename to a different file name (instead of overwriting)
* [ ] Session inhibitor during uploads, to prevent timeouts
* [ ] `beforeunload` handler during uploads, to prevent the page from being closed, reloaded, navigated away from, etc.