### PR TITLE
Implement delete button event handling and introduce keyboard navigation tests

### DIFF
--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -61,7 +61,7 @@ export const editPermissions = (Dialogs, selected, path) => {
     );
 };
 
-const ConfirmDeletionDialog = ({
+export const ConfirmDeletionDialog = ({
     path,
     selected,
     setSelected,

--- a/src/files-card-body.jsx
+++ b/src/files-card-body.jsx
@@ -35,7 +35,7 @@ import { ListingTable } from "cockpit-components-table.jsx";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import { ContextMenu } from "cockpit-components-context-menu.jsx";
-import { fileActions } from "./fileActions.jsx";
+import { fileActions, ConfirmDeletionDialog } from "./fileActions.jsx";
 
 const _ = cockpit.gettext;
 
@@ -259,6 +259,14 @@ export const FilesCardBody = ({
                 });
             } else if (e.key === "Enter" && selected.length === 1) {
                 onDoubleClickNavigate(selected[0]);
+            } else if (e.key === "Delete" && selected.length !== 0) {
+                const currentPath = path.join("/") + "/";
+                Dialogs.show(
+                    <ConfirmDeletionDialog
+                      selected={selected} path={currentPath}
+                      setSelected={setSelected}
+                    />
+                );
             }
         };
 

--- a/test/check-application
+++ b/test/check-application
@@ -27,6 +27,11 @@ class TestFiles(testlib.MachineCase):
         self.login_and_go("/files")
         self.browser.wait_not_present(".pf-c-empty-state")
 
+    # TODO: move to testlib.py
+    def press_special_key(self, name):
+        args = {"type": "keyDown", "key": name}
+        self.browser.cdp.invoke("Input.dispatchKeyEvent", **args)
+
     def delete_item(self, b, filetype, filename, expect_success=True):
         b.click(f"[data-item='{filename}']")
         b.click("#dropdown-menu")
@@ -790,6 +795,46 @@ class TestFiles(testlib.MachineCase):
                        "cannot create regular file '/home/admin/locked/newfile3': Operation not permitted")
         b.click(".breadcrumb-button:nth-of-type(3)")
         m.execute("chattr -i /home/admin/locked")
+
+    def testKeyboardNav(self):
+        b = self.browser
+        m = self.machine
+
+        self.enter_files()
+
+        create_files = ""
+        for i in range(0, 4):
+            create_files += f"touch /home/admin/file{i}; "
+        m.execute(create_files)
+
+        # Focus the iframe for global keybindings in Files.
+        b.eval_js("window.focus()")
+
+        b.click("[data-item='file0']")
+        b.wait_visible("[data-item='file0'].pf-m-selected")
+
+        self.press_special_key("ArrowRight")
+        b.wait_visible("[data-item='file1'].pf-m-selected")
+        self.press_special_key("ArrowLeft")
+        b.wait_visible("[data-item='file0'].pf-m-selected")
+
+        # Up / Down depends on the layout, this is tested on mobile where the
+        # width is two cards.
+        b.set_layout("mobile")
+        b.click("[data-item='file0']")
+        b.wait_visible("[data-item='file0'].pf-m-selected")
+
+        self.press_special_key("ArrowDown")
+        b.wait_visible("[data-item='file2'].pf-m-selected")
+        self.press_special_key("ArrowUp")
+        b.wait_visible("[data-item='file0'].pf-m-selected")
+
+        m.execute("mkdir /home/admin/foo")
+        b.click("[data-item='foo']")
+
+        b.wait_visible("[data-item='foo'].pf-m-selected")
+        self.press_special_key("Enter")
+        b.wait_text(".breadcrumb-button:nth-of-type(4)", "foo")
 
 
 if __name__ == '__main__':

--- a/test/check-application
+++ b/test/check-application
@@ -358,6 +358,20 @@ class TestFiles(testlib.MachineCase):
         m.execute("sudo chattr -i /home/admin/newfile")
         self.delete_item(b, "file", "newfile")
 
+        # Delete using keyboard shortcut
+        m.execute("touch /home/admin/delete1 /home/admin/delete2")
+        b.click("[data-item='delete1']")
+        b.mouse("[data-item='delete2']", "click", ctrlKey=True)
+        b.wait_visible("[data-item='delete1'].pf-m-selected")
+        b.wait_visible("[data-item='delete2'].pf-m-selected")
+        self.press_special_key("Delete")
+        b.wait_in_text("h1.pf-v5-c-modal-box__title", "Delete 2 items?")
+        b.click("button.pf-m-danger")
+
+        b.wait_not_present(".pf-v5-c-modal-box")
+        b.wait_not_present("[data-item='delete1']")
+        b.wait_not_present("[data-item='delete2']")
+
     def testCreate(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
This PR should add coverage for [keydown eventlistener](https://cockpit-logs.us-east-1.linodeobjects.com/pull-357-5d6166f7-20240404-205754-fedora-39-devel/Coverage/src/files-card-body.jsx.gcov.html) and implement the missing delete button functionality with a test.