### PR TITLE
Merge Confirmation and Force deletion modal

### DIFF
--- a/src/apis/spawnHelpers.jsx
+++ b/src/apis/spawnHelpers.jsx
@@ -18,9 +18,6 @@
  */
 
 import cockpit from "cockpit";
-import React from "react";
-
-import { ForceDeleteModal } from "../fileActions";
 
 const options = { err: "message", superuser: "try" };
 
@@ -28,39 +25,6 @@ const renameCommand = (selected, path, newPath, is_current_dir) => {
     return is_current_dir
         ? ["mv", path.join("/"), newPath]
         : ["mv", path.join("/") + "/" + selected.name, newPath];
-};
-
-export const spawnDeleteItem = (path, selected, setSelected, Dialogs) => {
-    cockpit.spawn([
-        "rm",
-        "-r",
-        ...selected.map(f => path + f.name)
-    ], options)
-            .then(() => {
-                setSelected([]);
-            })
-            .finally(Dialogs.close)
-            .catch(err => {
-                Dialogs.show(
-                    <ForceDeleteModal
-                      path={path}
-                      selected={selected}
-                      initialError={err.message}
-                    />
-                );
-            });
-};
-
-export const spawnForceDelete = (path, selected, setDeleteFailed, setErrorMessage, Dialogs) => {
-    cockpit.spawn([
-        "rm",
-        "-r",
-        ...selected.map(f => path + f.name)
-    ], options)
-            .then(Dialogs.close, err => {
-                setDeleteFailed(true);
-                setErrorMessage(err.message);
-            });
 };
 
 export const spawnRenameItem = (selected, name, path, Dialogs, setErrorMessage) => {

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -43,9 +43,7 @@ import { FileAutoComplete } from "../pkg/lib/cockpit-components-file-autocomplet
 import {
     spawnCreateDirectory,
     spawnCreateLink,
-    spawnDeleteItem,
     spawnEditPermissions,
-    spawnForceDelete,
     spawnPaste,
     spawnRenameItem
 } from "./apis/spawnHelpers";
@@ -67,25 +65,43 @@ const ConfirmDeletionDialog = ({
     setSelected,
 }) => {
     const Dialogs = useDialogs();
+    const [errorMessage, setErrorMessage] = useState(null);
+    const [forceDelete, setForceDelete] = useState(false);
 
     let modalTitle;
     if (selected.length > 1) {
-        modalTitle = cockpit.format(_("Delete $0 items?"), selected.length);
+        modalTitle = cockpit.format(forceDelete ? _("Force delete $0 items") : _("Delete $0 items?"), selected.length);
     } else {
         const selectedItem = selected[0];
         if (selectedItem.type === "reg") {
-            modalTitle = cockpit.format(_("Delete file $0?"), selectedItem.name);
+            modalTitle = cockpit.format(
+                forceDelete ? _("Force delete file $0?") : _("Delete file $0?"), selectedItem.name
+            );
         } else if (selectedItem.type === "lnk") {
-            modalTitle = cockpit.format(_("Delete link $0?"), selectedItem.name);
+            modalTitle = cockpit.format(
+                forceDelete ? _("Force delete link $0?") : _("Delete link $0?"), selectedItem.name
+            );
         } else if (selectedItem.type === "dir") {
-            modalTitle = cockpit.format(_("Delete directory $0?"), selectedItem.name);
+            modalTitle = cockpit.format(
+                forceDelete ? _("Force delete directory $0?") : _("Delete directory $0?"), selectedItem.name
+            );
         } else {
-            modalTitle = cockpit.format(_("Delete $0?"), selectedItem.name);
+            modalTitle = cockpit.format(forceDelete ? _("Force delete $0") : _("Delete $0?"), selectedItem.name);
         }
     }
 
     const deleteItem = () => {
-        spawnDeleteItem(path, selected, setSelected, Dialogs);
+        const args = ["rm", "-r"];
+        // TODO: Make force more sensible https://github.com/cockpit-project/cockpit-files/issues/363
+        cockpit.spawn([...args, ...selected.map(f => path + f.name)], { err: "message", superuser: "try" })
+                .then(() => {
+                    setSelected([]);
+                    Dialogs.close();
+                })
+                .catch(err => {
+                    setErrorMessage(err.message);
+                    setForceDelete(true);
+                });
     };
 
     return (
@@ -102,56 +118,13 @@ const ConfirmDeletionDialog = ({
                   <Button variant="link" onClick={Dialogs.close}>{_("Cancel")}</Button>
               </>
           }
-        />
-    );
-};
-
-export const ForceDeleteModal = ({ selected, path, initialError }) => {
-    const Dialogs = useDialogs();
-    const [errorMessage, setErrorMessage] = useState(initialError);
-    const [deleteFailed, setDeleteFailed] = useState(false);
-
-    let modalTitle;
-    if (selected.length > 1)
-        modalTitle = cockpit.format(_("Force delete $0 items?"), selected.length);
-    else {
-        const selectedItem = Array.isArray(selected)
-            ? selected[0]
-            : selected;
-        if (selectedItem.type === "reg") {
-            modalTitle = cockpit.format(_("Force delete file $0?"), selectedItem.name);
-        } else if (selectedItem.type === "lnk") {
-            modalTitle = cockpit.format(_("Force delete link $0?"), selectedItem.name);
-        } else if (selectedItem.type === "dir") {
-            modalTitle = cockpit.format(_("Force delete directory $0?"), selectedItem.name);
-        } else {
-            modalTitle = _("Force delete $0?", selectedItem.name);
-        }
-    }
-
-    const forceDeleteItem = () => {
-        spawnForceDelete(path, selected, setDeleteFailed, setErrorMessage, Dialogs);
-    };
-
-    return (
-        <Modal
-          position="top"
-          title={modalTitle}
-          titleIconVariant="warning"
-          variant={ModalVariant.small}
-          isOpen
-          onClose={Dialogs.close}
-          footer={!deleteFailed &&
-          <>
-              <Button variant="danger" onClick={forceDeleteItem}>{_("Force delete")}</Button>
-              <Button variant="link" onClick={Dialogs.close}>{_("Cancel")}</Button>
-          </>}
         >
+            {errorMessage &&
             <InlineNotification
               type="danger"
               text={errorMessage}
               isInline
-            />
+            />}
         </Modal>
     );
 };


### PR DESCRIPTION
When deleting fails we get presented with another modal the force delete modal. This modal is identical except the text and the displayed error. Merge those two while this does not make a lot of sense as they end up calling `rm` again with the same arguments this will need to be handled in a follow up.