### PR TITLE
dependabot: Group React and typescript related packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,16 @@ updates:
       esbuild:
         patterns:
           - "esbuild*"
+      react:
+        patterns:
+          - "react*"
       stylelint:
         patterns:
           - "stylelint*"
+      types:
+        patterns:
+          - "@types*"
+          - "types*"
       xterm:
         patterns:
           - "xterm*"


### PR DESCRIPTION
The type annotations get new releases very often and cause too much CI churn/conflicts otherwise.

react and react-dom need to be kept in sync.