### PR TITLE
/etc/login.defs is word-readable

### DIFF
--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -322,7 +322,7 @@ const EditPermissionsModal = ({ selected, path }) => {
     const [errorMessage, setErrorMessage] = useState(undefined);
     const accounts = useFile("/etc/passwd", { syntax: etcPasswdSyntax });
     const groups = useFile("/etc/group", { syntax: etcGroupSyntax });
-    const logindef = useFile("/etc/login.defs", { superuser: true });
+    const logindef = useFile("/etc/login.defs");
 
     if (!selected) {
         const directory_name = path[path.length - 1];


### PR DESCRIPTION
The superuser option is documented in our protocol docs as an optional string. The bridge converted true to `require` but in this instance /etc/login.defs is world readable so should not require superuser.