### PR TITLE
test: enable ruff preview rules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 118

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ exclude = [
     "node_modules/",
 ]
 line-length = 118
+preview = true
 src = []
 
 [tool.ruff.lint]


### PR DESCRIPTION
Ruff's preview rules now implements the rules which we used flake8 for.