### PR TITLE
Implement upload support

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -41,6 +41,7 @@ interface Alert {
     key: string,
     title: string,
     variant: AlertVariant,
+    detail?: string,
 }
 
 export interface FolderFileInfo extends FileInfo {
@@ -49,7 +50,7 @@ export interface FolderFileInfo extends FileInfo {
 }
 
 interface FilesContextType {
-    addAlert: (title: string, variant: AlertVariant, key: string) => void,
+    addAlert: (title: string, variant: AlertVariant, key: string, detail?: string) => void,
     cwdInfo: FileInfo | null,
 }
 
@@ -118,8 +119,8 @@ export const Application = () => {
     if (loading)
         return <EmptyStatePanel loading />;
 
-    const addAlert = (title: string, variant: AlertVariant, key: string) => {
-        setAlerts(prevAlerts => [...prevAlerts, { title, variant, key }]);
+    const addAlert = (title: string, variant: AlertVariant, key: string, detail?: string) => {
+        setAlerts(prevAlerts => [...prevAlerts, { title, variant, key, detail, }]);
     };
     const removeAlert = (key: string) => setAlerts(prevAlerts => prevAlerts.filter(alert => alert.key !== key));
 
@@ -140,7 +141,9 @@ export const Application = () => {
                                   />
                               }
                               key={alert.key}
-                            />
+                            >
+                                {alert.detail}
+                            </Alert>
                         ))}
                     </AlertGroup>
                     <FilesBreadcrumbs

--- a/src/files-folder-view.tsx
+++ b/src/files-folder-view.tsx
@@ -57,6 +57,7 @@ export const FilesFolderView = ({
               setIsGrid={setIsGrid}
               sortBy={sortBy}
               setSortBy={setSortBy}
+              path={path}
             />
             <FilesCardBody
               files={files}

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -23,6 +23,7 @@ import React, { useState } from "react";
 import {
     CardHeader,
     CardTitle,
+    Divider,
     Flex,
     MenuToggle,
     MenuToggleAction,
@@ -36,13 +37,25 @@ import {
 } from "@patternfly/react-core";
 import { GripVerticalIcon, ListIcon } from "@patternfly/react-icons";
 
+import { UploadButton } from "./upload-button";
+
 const _ = cockpit.gettext;
 
-export const FilesCardHeader = ({ currentFilter, onFilterChange, isGrid, setIsGrid, sortBy, setSortBy }:
-    { currentFilter: string, onFilterChange: (_event: React.FormEvent<HTMLInputElement>, value: string) => void,
-      isGrid: boolean, setIsGrid: React.Dispatch<React.SetStateAction<boolean>>,
-      sortBy: string, setSortBy: React.Dispatch<React.SetStateAction<string>>
-    }) => {
+export const FilesCardHeader = ({
+    currentFilter,
+    onFilterChange,
+    isGrid,
+    setIsGrid,
+    sortBy,
+    setSortBy,
+    path
+}: {
+    currentFilter: string,
+    onFilterChange: (_event: React.FormEvent<HTMLInputElement>, value: string) => void,
+    isGrid: boolean, setIsGrid: React.Dispatch<React.SetStateAction<boolean>>,
+    sortBy: string, setSortBy: React.Dispatch<React.SetStateAction<string>>
+    path: string[],
+}) => {
     return (
         <CardHeader className="card-actionbar">
             <CardTitle component="h2" id="files-card-header">
@@ -60,6 +73,10 @@ export const FilesCardHeader = ({ currentFilter, onFilterChange, isGrid, setIsGr
                 <ViewSelector
                   isGrid={isGrid} setIsGrid={setIsGrid}
                   setSortBy={setSortBy} sortBy={sortBy}
+                />
+                <Divider orientation={{ default: "vertical" }} />
+                <UploadButton
+                  path={path}
                 />
             </Flex>
         </CardHeader>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+    debugging?: string;
+}

--- a/src/upload-button.scss
+++ b/src/upload-button.scss
@@ -1,0 +1,81 @@
+button.progress-wrapper {
+  block-size: 100%;
+  aspect-ratio: 1;
+  padding: 0;
+
+  // Make the button look clickable on hover
+  &:hover {
+    outline: 2px solid var(--pf-v5-c-button--m-secondary--hover--after--BorderColor);
+  }
+}
+
+.progress-pie {
+  --progress-fill: var(--pf-v5-global--primary-color--100);
+  --progress-empty: var(--pf-v5-global--BorderColor--100);
+  /* Width can be set to 100% for a filled circle or to any units, including px */
+  --progress-width: 40%;
+
+  aspect-ratio: 1;
+  border-radius: 100%;
+  block-size: auto;
+  // Set "padding" to xs size (1/2 of sm)
+  inline-size: calc(100% - var(--pf-v5-global--spacer--sm));
+  line-height: var(--pf-v5-c-button--LineHeight);
+  display: inline-block;
+  vertical-align: middle;
+  /* Multiply by a float for a bit of anti-aliasing, while preserving 0% and 100% */
+  background: conic-gradient(
+    var(--progress-fill) var(--progress, 0),
+    var(--progress-empty) calc(var(--progress, 0) * 1.005)
+  );
+  /* Size from the edge, add a px for antialiasing */
+  mask-image: radial-gradient(
+    circle farthest-side,
+    transparent calc(100% - var(--progress-width)),
+    black calc(100% - var(--progress-width) + 1px)
+  );
+}
+
+/* Divider has no margin by default */
+.upload-progress {
+  margin-block-start: var(--pf-v5-global--spacer--md);
+  margin-block-end: var(--pf-v5-global--spacer--md);
+  flex: auto;
+
+  /* Force the progress percentage text to be 4 characters wide so the width
+   * doesn't jump when the percentage jumps from 9 => 10
+   * TODO: fill PF issue
+   */
+  .pf-v5-c-progress__measure {
+     inline-size: 4ch;
+  }
+}
+
+.upload-progress-flex {
+  .pf-v5-c-progress {
+    // Align % with label and trashcan
+    align-items: start;
+  }
+}
+
+/* Drop all padding to make the trashcan align with the Popover close button  */
+button.cancel-button {
+  padding: 0;
+}
+
+.conflict-modal-files {
+  padding-inline-start: var(--pf-v5-global--spacer--md);
+  padding-block-start: var(--pf-v5-global--spacer--md);
+  padding-block-end: var(--pf-v5-global--spacer--md);
+}
+
+.upload-popover {
+  // Set the max width to 32rem, but have it work on smaller screen sizes too
+  max-inline-size: min(32rem, 100vw - 8rem);
+
+  .pf-v5-c-popover__body {
+    // Set the minimum width to 14rem, but also allow it to work on smaller screen sizes
+    min-inline-size: min(14rem, 33vw);
+  }
+}
+

--- a/src/upload-button.tsx
+++ b/src/upload-button.tsx
@@ -1,0 +1,354 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React, { useState, useRef } from "react";
+
+import {
+    AlertVariant,
+    Button,
+    Checkbox,
+    Divider,
+    Modal,
+    ModalVariant,
+    Popover,
+    PopoverPosition,
+    Progress,
+    Flex,
+    FlexItem,
+} from "@patternfly/react-core";
+import { TrashIcon } from "@patternfly/react-icons";
+
+import { upload } from "cockpit-upload-helper";
+import { fmt_to_fragments } from "utils.jsx";
+import { useDialogs } from "dialogs.jsx";
+import * as timeformat from "timeformat";
+
+import { useFilesContext } from "./app";
+import { FileInfo } from "./fsinfo";
+
+import "./upload-button.scss";
+
+const _ = cockpit.gettext;
+
+const FileConflictDialog = ({
+    path,
+    file,
+    uploadFile,
+    isMultiUpload,
+}: {
+    path: string[];
+    file: FileInfo,
+    uploadFile: File,
+    isMultiUpload: boolean,
+}) => {
+    const Dialogs = useDialogs();
+    const [applyToAll, setApplyToAll] = React.useState<boolean>(false);
+
+    const handleReplace = () => {
+        Dialogs.close({ replace: true, applyToAll });
+    };
+
+    const handleSkip = () => {
+        Dialogs.close({ skip: true, applyToAll });
+    };
+
+    const handleCancel = () => {
+        Dialogs.reject(new Error("cancelled"));
+    };
+
+    return (
+        <Modal
+          position="top"
+          // @ts-expect-error incorrect PatternFly typing https://github.com/patternfly/patternfly-react/issues/10361
+          title={fmt_to_fragments(_("Replace file $0?"), <b>{uploadFile.name}</b>)}
+          titleIconVariant="warning"
+          variant={ModalVariant.medium}
+          onClose={handleCancel}
+          isOpen
+          footer={
+              <>
+                  <Button variant="warning" onClick={handleReplace}>{_("Replace")}</Button>
+                  {isMultiUpload &&
+                  <Button variant="secondary" onClick={handleSkip}>{_("Keep original")}</Button>}
+                  <Button variant="link" onClick={handleCancel}>{_("Cancel")}</Button>
+              </>
+          }
+        >
+            <p>
+                {cockpit.format(
+                    _("A file with the same name already exists in \"$0\". Replacing it will overwrite its content."),
+                    path.join('/')
+                )}
+            </p>
+            <Flex
+              spaceItems={{ default: "spaceItems3xl" }}
+              className="conflict-modal-files"
+            >
+                <FlexItem>
+                    <b>{_("New file")}</b>
+                    <p>{cockpit.format_bytes(uploadFile.size)}</p>
+                    <p>{timeformat.dateTime(uploadFile.lastModified)}</p>
+                </FlexItem>
+                <FlexItem>
+                    <b>{_("Original file on server")}</b>
+                    <p>{cockpit.format_bytes(file.size)}</p>
+                    {file.mtime &&
+                    <p>{timeformat.dateTime(file.mtime * 1000)}</p>}
+                </FlexItem>
+            </Flex>
+            {isMultiUpload &&
+            <Checkbox
+              id="replace-all"
+              label={_("Apply this action to all conflicting files")}
+              isChecked={applyToAll}
+              onChange={() => setApplyToAll(!applyToAll)}
+            />}
+        </Modal>
+    );
+};
+
+export const UploadButton = ({
+    path,
+} : {
+    path: string[],
+}) => {
+    const ref = useRef<HTMLInputElement>(null);
+    const { addAlert, cwdInfo } = useFilesContext();
+    const Dialogs = useDialogs();
+    const [showPopover, setPopover] = React.useState(false);
+    const [uploadedFiles, setUploadedFiles] = useState<{[name: string]:
+                                                        {file: File, progress: number, cancel:() => void}}>({});
+
+    const handleClick = () => {
+        if (ref.current) {
+            ref.current.click();
+        }
+    };
+
+    // Show a confirmation before closing the tab while uploading
+    const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
+        event.preventDefault();
+
+        // Included for legacy support, e.g. Chrome/Edge < 119
+        event.returnValue = true;
+    };
+
+    const onUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        cockpit.assert(event.target.files, "not an <input type='file'>?");
+        cockpit.assert(cwdInfo?.entries, "cwdInfo.entries is undefined");
+        let next_progress = 0;
+        const toUploadFiles = [];
+
+        const resetInput = () => {
+        // Reset input field in the case a download was cancelled and has to be re-uploaded
+        // https://stackoverflow.com/questions/26634616/filereader-upload-same-file-again-not-working
+            event.target.value = "";
+        };
+
+        let resolution;
+        let replaceAll = false;
+        let skipAll = false;
+        for (let i = 0; i < event.target.files.length; i++) {
+            const inputFile = event.target.files[i];
+            const file = cwdInfo?.entries[inputFile.name];
+
+            if (replaceAll)
+                toUploadFiles.push(inputFile);
+            else if (file && skipAll) {
+                continue;
+            } else if (file) {
+                try {
+                    resolution = await Dialogs.show(
+                        <FileConflictDialog
+                          path={path}
+                          file={file}
+                          uploadFile={inputFile}
+                          isMultiUpload={event.target.files.length > 1}
+                        />
+                    );
+                } catch (exc) {
+                    resetInput();
+                    return;
+                }
+
+                if (resolution.skip) {
+                    if (resolution.applyToAll)
+                        skipAll = true;
+                    continue;
+                }
+
+                if (resolution.applyToAll && resolution.replace)
+                    replaceAll = true;
+
+                toUploadFiles.push(inputFile);
+            } else {
+                toUploadFiles.push(inputFile);
+            }
+        }
+
+        if (toUploadFiles.length === 0) {
+            resetInput();
+            return;
+        }
+
+        window.addEventListener("beforeunload", beforeUnloadHandler);
+
+        const cancelledUploads = [];
+        await Promise.allSettled(toUploadFiles.map(async (file: File) => {
+            const tmp_path = path.slice();
+            tmp_path.push(file.name);
+            const destination = tmp_path.join('/');
+            const abort = new AbortController();
+
+            setUploadedFiles(oldFiles => {
+                return {
+                    [file.name]: { file, progress: 0, cancel: () => abort.abort() },
+                    ...oldFiles,
+                };
+            });
+
+            try {
+                await upload(destination, file, (progress) => {
+                    const now = performance.now();
+                    if (now < next_progress)
+                        return;
+                    next_progress = now + 200; // only rerender every 200ms
+                    setUploadedFiles(oldFiles => {
+                        const oldFile = oldFiles[file.name];
+                        return {
+                            ...oldFiles,
+                            [file.name]: { ...oldFile, progress },
+                        };
+                    });
+                }, abort.signal);
+                // TODO: pass { superuser: try } depending on directory owner
+            } catch (exc) {
+                cockpit.assert(exc instanceof Error, "Unknown exception type");
+                if (exc instanceof DOMException && exc.name === 'AbortError') {
+                    addAlert(_("Cancelled"), AlertVariant.warning, "upload",
+                             cockpit.format(_("Cancelled upload of $0"), file.name));
+                } else {
+                    addAlert(_("Upload error"), AlertVariant.danger, "upload-error", exc.toString());
+                }
+                cancelledUploads.push(file);
+            } finally {
+                setUploadedFiles(oldFiles => {
+                    const copy = { ...oldFiles };
+                    delete copy[file.name];
+                    return copy;
+                });
+            }
+        }));
+
+        resetInput();
+        window.removeEventListener("beforeunload", beforeUnloadHandler);
+
+        // If all uploads are cancelled, don't show an alert
+        if (cancelledUploads.length !== toUploadFiles.length) {
+            addAlert(_("Upload complete"), AlertVariant.success, "upload-success", _("Successfully uploaded file(s)"));
+        }
+    };
+
+    const isUploading = Object.keys(uploadedFiles).length !== 0;
+    let icon;
+
+    if (isUploading) {
+        let totalSize = 0;
+        let totalSent = 0;
+
+        Object.keys(uploadedFiles).forEach((key) => {
+            const uploadedFile = uploadedFiles[key];
+            totalSize += uploadedFile.file.size;
+            totalSent += uploadedFile.progress;
+        });
+
+        const overallProgress = ((totalSent / totalSize) * 100).toFixed(2);
+
+        icon = (
+            <Button
+              onClick={() => setPopover(true)}
+              className="progress-wrapper"
+              variant="plain"
+              icon={
+                  <div
+                    id="upload-progress-btn"
+                    className="progress-pie"
+                    title={cockpit.format(_("Upload $0% completed"), overallProgress)}
+                    style={{ "--progress": `${overallProgress}%` } as React.CSSProperties}
+                  />
+              }
+            />
+        );
+    }
+
+    return (
+        <>
+            <Popover
+              className="upload-popover"
+              position={PopoverPosition.bottom}
+              headerContent={<p>{_("Uploads")}</p>}
+              bodyContent={Object.keys(uploadedFiles).map((key, index) => {
+                  const file = uploadedFiles[key];
+                  return (
+                      <React.Fragment key={index}>
+                          <Divider />
+                          <Flex className="upload-progress-flex" flexWrap={{ default: 'nowrap' }}>
+                              <Progress
+                                key={file.file.name}
+                                className={`upload-progress-${index} upload-progress pf-v5-m-tabular-nums`}
+                                value={file.progress}
+                                title={file.file.name}
+                                max={file.file.size}
+                              />
+                              <Button
+                                variant="plain"
+                                icon={<TrashIcon />}
+                                className={`cancel-button-${index} cancel-button`}
+                                onClick={file.cancel}
+                                aria-label={cockpit.format(_("Cancel upload of $0"), file.file.name)}
+                              />
+                          </Flex>
+                      </React.Fragment>
+                  );
+              })}
+              isVisible={showPopover}
+              shouldClose={() => setPopover(false)}
+            >
+                {icon}
+            </Popover>
+            <Button
+              id="upload-file-btn"
+              className="upload-button"
+              variant="secondary"
+              isDisabled={isUploading || cwdInfo?.entries === undefined}
+              onClick={handleClick}
+            >
+                {_("Upload")}
+            </Button>
+            <input
+              ref={ref}
+              type="file"
+              hidden
+              multiple
+              onChange={onUpload}
+            />
+        </>
+    );
+};

--- a/test/check-application
+++ b/test/check-application
@@ -4,6 +4,10 @@
 # "class Browser" and "class MachineCase" for the available API.
 
 import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
 
 # import Cockpit's machinery for test VMs and its browser test API
 import testlib
@@ -943,6 +947,258 @@ class TestFiles(testlib.MachineCase):
         b.mouse("[data-item='newdir']", "dblclick")
         b.wait_visible("[data-item='newfile2']")
         b.click(".breadcrumb-button:nth-of-type(3)")
+
+    @testlib.skipBrowser(".upload_files() doesn't work on Firefox", "firefox")
+    @testlib.skipImage("Debian-testing has Cockpit 311 without new upload support in fsreplace1", "debian-testing")
+    def testUpload(self):
+        b = self.browser
+        m = self.machine
+
+        self.enter_files()
+
+        def get_piechart_progress(sel):
+            b.wait_visible(sel)
+            style = b.attr(sel, "style")
+            m = re.search(r"--progress: (\d+).\d+%;", style)
+            assert m is not None
+            return int(m.group(1))
+
+        def dir_file_count(directory):
+            return int(m.execute(f"find {directory} -mindepth 1 -maxdepth 1 | wc -l").strip())
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Test cancelling of upload
+            big_file = str(Path(tmpdir) / "bigfile.img")
+            subprocess.check_call(["truncate", "-s", "1500MB", big_file])
+
+            m.execute("runuser -u admin mkdir /home/admin/Downloads")
+            b.wait_visible("[data-item='Downloads']")
+            b.mouse("[data-item='Downloads']", "dblclick")
+            b.wait_not_present(".pf-v5-c-empty-state")
+
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", [big_file])
+            b.wait_visible("#upload-file-btn:disabled")
+
+            # Wait for some progress and cancel
+            b.click("#upload-progress-btn")
+            b.wait(lambda: get_piechart_progress("#upload-progress-btn") >= 2)
+            b.wait_in_text(".upload-progress-0", "bigfile.img")
+            b.wait(lambda: b.get_pf_progress_value(".upload-progress-0") >= 2)
+
+            b.click(".cancel-button-0")
+
+            b.wait_not_present("#upload-progress-btn")
+            b.wait_visible("#upload-file-btn")
+            b.wait_in_text(".pf-v5-c-alert__description", "Cancelled upload of bigfile.img")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_not_present(".pf-v5-c-alert__action")
+            self.assertEqual(dir_file_count("/home/admin/Downloads"), 0)
+
+            # Early ENOSPC error (before we would block on 'ack')
+            m.execute("mkdir -p /mnt/upload; mount -t tmpfs -o size=1M none /mnt/upload;")
+            # TODO: cockpit-bridge keeps a handle on /mnt/upload, pkill is a hack
+            self.addCleanup(m.execute, """
+                pkill cockpit-bridge || true;
+                while mountpoint -q /mnt/upload && ! umount /mnt/upload; do sleep 0.2; done;
+                rmdir /mnt/upload;
+            """)
+
+            b.go("/files#/?path=/mnt/upload")
+            self.browser.wait_not_present(".pf-c-empty-state")
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", [big_file])
+
+            b.wait_in_text(".pf-v5-c-alert__description", "No space left on device")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_not_present(".pf-v5-c-alert__action")
+            self.assertEqual(dir_file_count("/home/admin/Downloads"), 0)
+
+            # Multi upload
+            dest_dir = "/home/admin/project"
+            m.execute(['runuser', '-u', 'admin', 'mkdir', dest_dir])
+            b.go(f"/files#/?path={dest_dir}")
+            self.browser.wait_not_present(".pf-c-empty-state")
+
+            files = [str(Path(tmpdir) / f"{i}.txt") for i in range(0, 5)]
+            test_data = "this is a test"
+            for file in files:
+                with open(file, "w") as fp:
+                    fp.write(test_data)
+
+            def verify_uploaded_files(changed=False):
+                for f in files:
+                    contents = m.execute(f"cat {dest_dir}/{os.path.basename(f)}")
+                    if changed:
+                        self.assertNotEqual(contents, test_data)
+                    else:
+                        self.assertEqual(contents, test_data)
+
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", [str(Path(tmpdir) / file) for file in files])
+            with b.wait_timeout(30):
+                b.wait(lambda: int(m.execute(f"ls {dest_dir} | wc -l").strip()) == len(files))
+
+            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_not_present(".pf-v5-c-alert__action")
+
+            # Verify ownership
+            filename = os.path.basename(files[0])
+            b.click(f"[data-item='{filename}']")
+            b.wait_text("#sidebar-card-header", filename)
+            b.wait_text("#description-list-owner dd", "admin")
+            b.wait_text("#description-list-group dd", "admin")
+
+            # Conflict handling
+            # change the content of the files locally so we can detect
+            # overwrites and make it noticably bigger so we can assert that in
+            # the dialog details
+            for f in files:
+                with open(f, "w") as fp:
+                    fp.write("new content" * 20)
+
+            # Cancel does not overwrite
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", [files[0]])
+            b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Replace file {filename}?")
+            # TODO: Validate the contents of the dialog
+            b.click("button.pf-m-link:contains('Cancel')")
+            # content did not change as we cancelled
+            self.assertEqual(m.execute(f"cat {dest_dir}/{filename}"), "this is a test")
+
+            # Overwrite
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", [files[0]])
+            b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Replace file {filename}?")
+            b.click("button.pf-m-warning:contains('Replace')")
+            b.wait_not_present(".pf-v5-c-modal-box")
+
+            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_not_present(".pf-v5-c-alert__action")
+
+            self.assertEqual(m.execute(f"cat {dest_dir}/{filename}"),
+                            subprocess.check_output(["cat", files[0]]).decode())
+            # reset test file
+            m.execute(f"echo -n this is a test > {dest_dir}/{filename}")
+
+            # Multiple files
+
+            # Cancel all
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", files)
+
+            b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Replace file {filename}?")
+            b.wait_in_text(".pf-v5-c-check__label", "Apply this action to all conflicting files")
+            # Cancelling calls all
+            b.click("button.pf-m-link:contains('Cancel')")
+            b.wait_not_present(".pf-v5-c-modal-box")
+
+            verify_uploaded_files()
+
+            # Keep original for all
+
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", files)
+
+            b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Replace file {filename}?")
+            b.wait_in_text(".pf-v5-c-check__label", "Apply this action to all conflicting files")
+            b.set_checked("#replace-all", True)
+            b.click("button.pf-m-secondary:contains('Keep original')")
+            b.wait_not_present(".pf-v5-c-modal-box")
+
+            verify_uploaded_files()
+
+            # Replace all
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", files)
+
+            b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Replace file {filename}?")
+            b.wait_in_text(".pf-v5-c-check__label", "Apply this action to all conflicting files")
+            b.set_checked("#replace-all", True)
+            b.click("button.pf-m-warning:contains('Replace')")
+            b.wait_not_present(".pf-v5-c-modal-box")
+
+            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_not_present(".pf-v5-c-alert__action")
+
+            verify_uploaded_files(changed=True)
+
+            # Upload one file new file which is uploaded automatically
+            newfile = str(Path(tmpdir) / "newfile.txt")
+            with open(newfile, "w") as fp:
+                fp.write("bazinga")
+
+            files.append(newfile)
+
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", files)
+
+            # We only get asked about existing files
+            for file in files:
+                filename = os.path.basename(file)
+                if file != files[-1]:
+                    b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Replace file {filename}?")
+                    b.click("button.pf-m-secondary:contains('Keep original')")
+
+            b.wait_not_present(".pf-v5-c-modal-box")
+            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_not_present(".pf-v5-c-alert__action")
+
+            b.wait_visible(f"[data-item='{os.path.basename(newfile)}']")
+
+            # Replace a the last file
+
+            with open(newfile, "w") as fp:
+                fp.write("new content")
+
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", files)
+
+            # We only get asked about existing files
+            for file in files:
+                filename = os.path.basename(file)
+                b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Replace file {filename}?")
+                if file == files[-1]:
+                    b.click("button.pf-m-warning:contains('Replace')")
+                else:
+                    b.click("button.pf-m-secondary:contains('Keep original')")
+
+            b.wait_not_present(".pf-v5-c-modal-box")
+            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_not_present(".pf-v5-c-alert__action")
+
+            self.assertEqual(m.execute(f"cat {dest_dir}/{filename}"), "new content")
+
+            # Non-admin session
+            b.drop_superuser()
+            m.execute(f"rm {dest_dir}/{filename}; touch {dest_dir}/update.txt")
+            b.wait_not_present(f"[data-item='{filename}']")
+            # Wait for the update to appear so uploading doesn't flake
+            b.wait_visible("[data-item='update.txt']")
+
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", [files[-1]])
+
+            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_not_present(".pf-v5-c-alert__action")
+
+            b.wait_visible(f"[data-item='{filename}']")
+
+            # Permission error
+            b.go("/files#/?path=/")
+            self.browser.wait_not_present(".pf-c-empty-state")
+
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", [files[0]])
+            b.wait_in_text(".pf-v5-c-alert__description", "UploadError: Not permitted to perform this action")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_not_present(".pf-v5-c-alert__action")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This implements https://github.com/cockpit-project/cockpit-files/issues/378 

* [x] Wait for cockpit release with `send-acks` support and refreshed images for creating tests
* [x] Implement conflict dialog mockup design from @garrett 
* [x] Pull cockpit-lib-update for `cockpit.format_bytes` typescript shenanigans
* [x] Design tweaks
* [x] Write tests
    * [x] Test upload success
      * [x] Test upload cancel
      * [x] Test upload permission issues
      * [x] Test upload disk full
      * [x] Test multi upload
      * [x] Test progress popover
      * [x] Test file conflict
          * [x] Skip
            * [x] Replace
            * [x] Cancel
            * [x] Skip all
            * [x] Replace all
 
----

![image](https://github.com/cockpit-project/cockpit-files/assets/67428/466a7ccf-d6ae-4aa4-a9f8-819787cfb188)


Conflict handling

![image](https://github.com/cockpit-project/cockpit-files/assets/67428/c4cc4398-722d-4f80-8a94-37592624bcbd)