### PR TITLE
Drop useless conditional

### DIFF
--- a/src/files-card-body.jsx
+++ b/src/files-card-body.jsx
@@ -191,7 +191,7 @@ export const FilesCardBody = ({
             if (ev.detail > 1) {
                 onDoubleClickNavigate(file);
             } else {
-                if (!ev.ctrlKey || selected === path[path.length - 1]) {
+                if (!ev.ctrlKey) {
                     setSelected([file]);
                 } else {
                     setSelected(s => {


### PR DESCRIPTION
This compares the `selected` object against a string, Typescript already warns this makes no sense when I converted this a to a `tsx` file.