### PR TITLE
eslint: enable no-useless-fragment rule by default

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,7 @@
         "react/prop-types": "off",
         "react/jsx-handler-names": "off",
         "react/jsx-max-props-per-line": [1, { "maximum": 2 }],
+        "react/jsx-no-useless-fragment": "error",
 
         "jsx-a11y/anchor-is-valid": "off"
     },


### PR DESCRIPTION
This rule is not part of the standard ESLint recommends set but is useful and can be auto-fixed.