### PR TITLE
packit.yaml: provide copr main builds for testing

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -33,6 +33,13 @@ jobs:
       - fedora-development
       - fedora-latest-stable
 
+  - job: copr_build
+    trigger: commit
+    branch: "^main$"
+    owner: "@cockpit"
+    project: "main-builds"
+    preserve_project: True
+
   # Build releases in COPR: https://packit.dev/docs/configuration/#copr_build
   #- job: copr_build
   #  trigger: release


### PR DESCRIPTION
Provide COPR main builds for folks who are interested in testing files and later to eventually reverse test Cockpit-files in Cockpit.

Closes: #394

---

Same as https://github.com/cockpit-project/cockpit-podman/pull/1365