### PR TITLE
Don't always add a divider in context menu's

### DIFF
--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -672,14 +672,16 @@ export const fileActions = (path, files, selected, setSelected, clipboard, setCl
                     );
                 }
             },
-            { type: "divider" },
         );
         if (selected[0].type === "reg")
-            menuItems.push({
-                id: "download-item",
-                title: _("Download"),
-                onClick: () => downloadFile(currentPath, selected[0])
-            });
+            menuItems.push(
+                { type: "divider" },
+                {
+                    id: "download-item",
+                    title: _("Download"),
+                    onClick: () => downloadFile(currentPath, selected[0])
+                }
+            );
     } else if (selected.length > 1) {
         menuItems.push(
             {


### PR DESCRIPTION
In 337c1e6cbdcf0c590 we introduced file download support which always adds a divider regardless if the file can be downloaded.

Closes: #392