### PR TITLE
Don't move a file under a directory when renaming

### DIFF
--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -206,8 +206,8 @@ const RenameItemModal = ({ path, selected }) => {
             : path.join("/") + "/" + name;
 
         cockpit.spawn(is_current_dir
-            ? ["mv", path.join("/"), newPath]
-            : ["mv", path.join("/") + "/" + selected.name, newPath],
+            ? ["mv", "--no-target-directory", "--no-clobber", path.join("/"), newPath]
+            : ["mv", "--no-target-directory", "--no-clobber", path.join("/") + "/" + selected.name, newPath],
                       { superuser: "try", err: "message" })
                 .then(() => {
                     if (is_current_dir) {

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -200,19 +200,11 @@ const RenameItemModal = ({ path, selected }) => {
     }
 
     const renameItem = () => {
-        const is_current_dir = path.at(-1) === selected.name;
-        const newPath = is_current_dir
-            ? path.slice(0, -1).join("/") + "/" + name
-            : path.join("/") + "/" + name;
+        const newPath = path.join("/") + "/" + name;
 
-        cockpit.spawn(is_current_dir
-            ? ["mv", "--no-target-directory", "--no-clobber", path.join("/"), newPath]
-            : ["mv", "--no-target-directory", "--no-clobber", path.join("/") + "/" + selected.name, newPath],
+        cockpit.spawn(["mv", "--no-target-directory", "--no-clobber", path.join("/") + "/" + selected.name, newPath],
                       { superuser: "try", err: "message" })
                 .then(() => {
-                    if (is_current_dir) {
-                        cockpit.location.go("/", { path: encodeURIComponent(newPath) });
-                    }
                     Dialogs.close();
                 }, err => setErrorMessage(err.message));
     };

--- a/test/check-application
+++ b/test/check-application
@@ -545,6 +545,30 @@ class TestFiles(testlib.MachineCase):
         self.rename_item(b, "newdir1", "new dir1")
         b.wait_visible("[data-item='new dir1']")
 
+        # Rename to an existing directory should not move the file into the directory
+        m.execute("""
+        touch /home/admin/newfile
+        mkdir /home/admin/dest
+        """)
+        b.wait_visible("[data-item='newfile']")
+        b.wait_visible("[data-item='dest']")
+        self.rename_item(b, "newfile", "dest")
+        self.wait_modal_inline_alert(b, "mv: not replacing '/home/admin/dest'")
+        b.click("button.pf-m-link:contains('Cancel')")
+        b.wait_not_present(".pf-v5-c-modal-box")
+
+        # Renaming existing file should not overwrite
+        m.execute("""
+        touch /home/admin/existing
+        touch /home/admin/torename
+        """)
+        b.wait_visible("[data-item='existing']")
+        b.wait_visible("[data-item='torename']")
+        self.rename_item(b, "torename", "existing")
+        self.wait_modal_inline_alert(b, "mv: not replacing '/home/admin/existing'")
+        b.click("button.pf-m-link:contains('Cancel')")
+        b.wait_not_present(".pf-v5-c-modal-box")
+
         # Renaming protected item should give an error
         m.execute("sudo chattr +i /home/admin/new\\ dir1")
         self.rename_item(b, "new dir1", "testdir")


### PR DESCRIPTION
We rename in Files by moving the file to the new filename but when this is a directory `mv` moves the file to that directory instead. This is quite logical in a shell but not in a GUI, there it is unexpected behaviour.

Closes: #399