### PR TITLE
Don't spread an already newly created Array

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -110,7 +110,7 @@ export const Application = () => {
     const addAlert = (title: string, variant: AlertVariant, key: string) => {
         setAlerts(prevAlerts => [...prevAlerts, { title, variant, key }]);
     };
-    const removeAlert = (key: string) => setAlerts(prevAlerts => [...prevAlerts.filter(alert => alert.key !== key)]);
+    const removeAlert = (key: string) => setAlerts(prevAlerts => prevAlerts.filter(alert => alert.key !== key));
 
     return (
         <Page>


### PR DESCRIPTION
prevAlerts.filter() returns a new Array so we don't have to spread it to create a new array.

Found by oxlint's eslint-unicorn-plugin rule. 