### PR TITLE
Renaming to existing directory name moves under directory

### DIFF
--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -203,7 +203,7 @@ const RenameItemModal = ({ path, selected }) => {
     const renameItem = () => {
         const newPath = path.join("/") + "/" + name;
 
-        cockpit.spawn(["mv", path.join("/") + "/" + selected.name, newPath],
+        cockpit.spawn(["mv", "--no-target-directory", path.join("/") + "/" + selected.name, newPath],
                       { superuser: "try", err: "message" })
                 .then(() => {
                     Dialogs.close();

--- a/test/check-application
+++ b/test/check-application
@@ -544,6 +544,18 @@ class TestFiles(testlib.MachineCase):
         self.rename_item(b, "newdir1", "new dir1")
         b.wait_visible("[data-item='new dir1']")
 
+        # Rename to an existing directory should not move the file into the directory
+        m.execute("""
+        touch /home/admin/newfile
+        mkdir /home/admin/dest
+        """)
+        b.wait_visible("[data-item='newfile']")
+        b.wait_visible("[data-item='dest']")
+        self.rename_item(b, "newfile", "dest")
+        self.wait_modal_inline_alert(b, "mv: cannot overwrite directory '/home/admin/dest' with non-directory")
+        b.click("button.pf-m-link:contains('Cancel')")
+        b.wait_not_present(".pf-v5-c-modal-box")
+
         # Renaming protected item should give an error
         m.execute("sudo chattr +i /home/admin/new\\ dir1")
         self.rename_item(b, "new dir1", "testdir")


### PR DESCRIPTION
We rename in Files by moving the file to the new filename but when this is a directory `mv` moves the file to that directory instead. This is quite logical in a shell but not in a GUI, there it is unexpected behaviour.

Related: #399

---

Note this is a partial fix, we want to actually pass files to the dialog to check if a directory or file already exists. However in no circumstance do we want a rename to move a file under an existing directory. So we should always invoke `mv` with `--no-target-directory`.