### PR TITLE
.github: add weblate sync pot file workflow

### DIFF
--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -1,0 +1,42 @@
+name: weblate-sync-pot
+on:
+  schedule:
+    # Run this every morning
+    - cron: '45 2 * * *'
+  # can be run manually on https://github.com/cockpit-project/cockpit-files/actions
+  workflow_dispatch:
+
+jobs:
+  pot-upload:
+    environment: cockpit-files-weblate
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends npm make gettext appstream
+
+      - name: Clone source repository
+        uses: actions/checkout@v4
+        with:
+          path: src
+
+      - name: Generate .pot file
+        run: make -C src po/files.pot
+
+      - name: Clone weblate repository
+        uses: actions/checkout@v4
+        with:
+          path: weblate
+          repository: ${{ github.repository }}-weblate
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Commit .pot to weblate repo
+        run: |
+          cp src/po/files.pot weblate/files.pot
+          git config --global user.name "GitHub Workflow"
+          git config --global user.email "cockpituous@cockpit-project.org"
+          git -C weblate commit -m "Update source file" -- files.pot
+          git -C weblate push


### PR DESCRIPTION
As far as I know this requires a token to deploy which we need to get deployed by https://github.com/cockpit-project/bots/pull/6380

Verified that a pot file is created locally.

```
[jelle@t14s][~/projects/cockpit-navigator]%make  po/files.pot
pkg/lib/html2po.js -o po/files.html.pot $(find src -name '*.html')
xgettext --default-domain=files --output=po/files.js.pot --language=C --keyword= \
        --add-comments=Translators: \
        --keyword=_:1,1t --keyword=_:1c,2,2t --keyword=C_:1c,2 \
        --keyword=N_ --keyword=NC_:1c,2 \
        --keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
        --keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \
        --keyword=gettextCatalog.getString:1,3c --keyword=gettextCatalog.getPlural:2,3,4c \
        --from-code=UTF-8 $(find src/ -name '*.js' -o -name '*.jsx')
pkg/lib/manifest2po.js src/manifest.json -o po/files.manifest.pot
xgettext --default-domain=files --output=po/files.metainfo.pot org.cockpit-project.files.metainfo.xml
msgcat --sort-output --output-file=po/files.pot po/files.html.pot po/files.js.pot po/files.manifest.pot po/files.metainfo.pot
```