### PR TITLE
Remove paste into folder functionality, Check for the existence of a file or directory when pasting

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -51,3 +51,12 @@ export function * map_permissions<T>(func: (value: number, label: string) => T) 
         yield func(value, label);
     }
 }
+
+export function basename(path: string) {
+    const elements = path.split('/');
+    if (elements.length === 0) {
+        return '/';
+    } else {
+        return elements[elements.length - 1];
+    }
+}

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -508,16 +508,6 @@ export const fileActions = (path, selected, setSelected, clipboard, setClipboard
                 title: _("Copy"),
                 onClick: () => setClipboard([currentPath + selected[0].name]),
             },
-            ...(selected[0].type === "dir")
-                ? [
-                    {
-                        id: "paste-into-directory",
-                        title: _("Paste into directory"),
-                        onClick: () => spawnPaste(clipboard, [currentPath + selected[0].name]),
-                        isDisabled: clipboard.length === 0
-                    }
-                ]
-                : [],
             { type: "divider" },
             {
                 id: "edit-permissions",

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -40,7 +40,7 @@ import {
 } from "pam_user_parser.js";
 import { superuser } from "superuser";
 
-import { map_permissions, inode_types } from "./common";
+import { map_permissions, inode_types, basename } from "./common";
 import { useFilesContext } from "./app";
 
 const _ = cockpit.gettext;
@@ -467,11 +467,18 @@ const downloadFile = (currentPath, selected) => {
     window.open(`${prefix}?${query}`);
 };
 
-export const fileActions = (path, selected, setSelected, clipboard, setClipboard, addAlert, Dialogs) => {
+export const fileActions = (path, selected, setSelected, clipboard, setClipboard, cwdInfo, addAlert, Dialogs) => {
     const currentPath = path.join("/") + "/";
     const menuItems = [];
 
     const spawnPaste = (sourcePaths, targetPath) => {
+        const existingFiles = sourcePaths.filter(sourcePath => cwdInfo?.entries[basename(sourcePath)]);
+        if (existingFiles.length > 0) {
+            addAlert(_("Pasting failed"), "danger", "paste-error",
+                     cockpit.format(_("\"$0\" exists, not overwriting with paste."),
+                                    existingFiles.map(basename).join(", ")));
+            return;
+        }
         cockpit.spawn([
             "cp",
             "-R",

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -471,11 +471,11 @@ export const fileActions = (path, selected, setSelected, clipboard, setClipboard
     const currentPath = path.join("/") + "/";
     const menuItems = [];
 
-    const spawnPaste = (sourcePath, targetPath) => {
+    const spawnPaste = (sourcePaths, targetPath) => {
         cockpit.spawn([
             "cp",
             "-R",
-            ...sourcePath,
+            ...sourcePaths,
             targetPath
         ]).catch(err => addAlert(err.message, "danger", new Date().getTime()));
     };

--- a/src/files-card-body.jsx
+++ b/src/files-card-body.jsx
@@ -80,9 +80,9 @@ const compare = (sortBy) => {
 
 const ContextMenuItems = ({ path, selected, setSelected, clipboard, setClipboard }) => {
     const Dialogs = useDialogs();
-    const { addAlert } = useFilesContext();
+    const { addAlert, cwdInfo } = useFilesContext();
     const menuItems = fileActions(path, selected, setSelected,
-                                  clipboard, setClipboard, addAlert, Dialogs);
+                                  clipboard, setClipboard, cwdInfo, addAlert, Dialogs);
 
     return (
         <MenuList>

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -123,7 +123,7 @@ export const SidebarPanelDetails = ({
 
     const menuItems = fileActions(path, selected, setSelected,
                                   clipboard, setClipboard,
-                                  addAlert, Dialogs).map((option, i) => {
+                                  cwdInfo, addAlert, Dialogs).map((option, i) => {
         if (option.type === "divider")
             return <Divider key={i} />;
         return (

--- a/test/check-application
+++ b/test/check-application
@@ -938,19 +938,6 @@ class TestFiles(testlib.MachineCase):
         self.assertEqual(m.execute("head -n 1 /home/admin/newdir/newfile"), "test_text\n")
         b.click(".breadcrumb-button:nth-of-type(4)")
 
-        # Paste into directory
-        self.browser.wait_not_present(".pf-c-empty-state")
-        m.execute("runuser -u admin touch /home/admin/newfile2")
-        b.click("[data-item='newfile2']")
-        b.click("#dropdown-menu")
-        b.click("#copy-item")
-        b.click("[data-item='newdir']")
-        b.click("#dropdown-menu")
-        b.click("#paste-into-directory")
-        b.mouse("[data-item='newdir']", "dblclick")
-        b.wait_visible("[data-item='newfile2']")
-        b.click(".breadcrumb-button:nth-of-type(3)")
-
     @testlib.skipBrowser(".upload_files() doesn't work on Firefox", "firefox")
     @testlib.skipImage("Debian-testing has Cockpit 311 without new upload support in fsreplace1", "debian-testing")
     def testUpload(self):

--- a/test/check-application
+++ b/test/check-application
@@ -533,7 +533,6 @@ class TestFiles(testlib.MachineCase):
 
         # Rename folder from context menu
         b.mouse("[data-item='newdir']", "contextmenu")
-        b.wait_in_text(".contextMenu li:nth-child(5) button", "Rename")
         b.click(".contextMenu button:contains('Rename')")
         b.set_input_text("#rename-item-input", "newdir1")
         b.click("button.pf-m-primary")
@@ -543,7 +542,6 @@ class TestFiles(testlib.MachineCase):
         m.execute("useradd testuser")
         b.click("[data-item='newdir1']")
         b.mouse("[data-item='newdir1']", "contextmenu")
-        b.wait_in_text(".contextMenu li:nth-child(4) button", "Edit permissions")
         b.click(".contextMenu button:contains('Edit permissions')")
         b.select_from_dropdown("#edit-permissions-owner", "testuser")
         b.click("button.pf-m-primary")

--- a/test/check-application
+++ b/test/check-application
@@ -924,10 +924,22 @@ class TestFiles(testlib.MachineCase):
         b.wait_visible("[data-item='newfile']")
         self.assertEqual(m.execute("head -n 1 /home/admin/newdir/newfile"), "test_text\n")
         b.click(".breadcrumb-button:nth-of-type(4)")
+        self.browser.wait_not_present(".pf-c-empty-state")
 
         # Copy/paste directory
-        self.browser.wait_not_present(".pf-c-empty-state")
         m.execute("runuser -u admin mkdir /home/admin/copyDir")
+        b.click("[data-item='copyDir']")
+        b.click("#dropdown-menu")
+        b.click("#copy-item")
+        b.mouse("[data-item='newdir']", "dblclick")
+        b.click("#dropdown-menu")
+        b.click("#paste-item")
+        b.wait_visible("[data-item='copyDir']")
+        b.click(".breadcrumb-button:nth-of-type(4)")
+        self.browser.wait_not_present(".pf-c-empty-state")
+
+        # File already exists error
+        m.execute("runuser -u admin echo 'changed' > /home/admin/newfile")
         b.click("[data-item='newfile']")
         b.click("#dropdown-menu")
         b.click("#copy-item")
@@ -936,7 +948,10 @@ class TestFiles(testlib.MachineCase):
         b.click("#paste-item")
         b.wait_visible("[data-item='newfile']")
         self.assertEqual(m.execute("head -n 1 /home/admin/newdir/newfile"), "test_text\n")
+        b.wait_in_text("h4.pf-v5-c-alert__title", "Pasting failed")
+        b.wait_in_text(".pf-v5-c-alert__description", "\"newfile\" exists")
         b.click(".breadcrumb-button:nth-of-type(4)")
+        self.browser.wait_not_present(".pf-c-empty-state")
 
     @testlib.skipBrowser(".upload_files() doesn't work on Firefox", "firefox")
     @testlib.skipImage("Debian-testing has Cockpit 311 without new upload support in fsreplace1", "debian-testing")


### PR DESCRIPTION
When copy pasting pass the `--archive` flag to `cp` so permissions are retained. This also allows us to enable superuser try as permissions are now retained.

Related: #435