### PR TITLE
packaging: quote the depends with a version comparison

### DIFF
--- a/packaging/arch/PKGBUILD.in
+++ b/packaging/arch/PKGBUILD.in
@@ -5,7 +5,7 @@ pkgdesc='A filesystem browser for Cockpit'
 arch=('any')
 url='https://github.com/cockpit-project/cockpit-files'
 license=(LGPL)
-depends=(cockpit>=310.1)
+depends=("cockpit>=310.1")
 source=("SOURCE")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
Quoting is needed when using versioned depends.

==> WARNING: Skipping all source file integrity checks.
/startdir/PKGBUILD: line 8: syntax error near unexpected token `>'
/startdir/PKGBUILD: line 8: `depends=(cockpit>=310.1)'