### PR TITLE
Add ownership options for "Create directory"

### DIFF
--- a/src/dialogs/mkdir.tsx
+++ b/src/dialogs/mkdir.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from 'react';
+import {
+    Button,
+    Form, FormGroup,
+    FormSelect, FormSelectOption,
+    Modal, ModalVariant,
+    Stack, TextInput,
+} from '@patternfly/react-core';
+
+import cockpit from 'cockpit';
+import { useDialogs } from 'dialogs';
+import { InlineNotification } from 'cockpit-components-inline-notification';
+import { FormHelper } from 'cockpit-components-form-helper';
+import { superuser } from 'superuser';
+
+import { useId, get_owner_candidates } from '../ownership';
+import { useFilesContext } from '../app';
+
+const _ = cockpit.gettext;
+
+function check_name(candidate: string) {
+    if (candidate === "") {
+        return _("Directory name cannot be empty.");
+    } else if (candidate.length >= 256) {
+        return _("Directory name too long.");
+    } else if (candidate.includes("/")) {
+        return _("Directory name cannot include a /.");
+    } else {
+        return undefined;
+    }
+}
+
+async function create_directory(path: string, owner?: string) {
+    if (owner !== undefined) {
+        const opts = { err: "message", superuser: "require" } as const;
+        await cockpit.spawn(["mkdir", path], opts);
+        await cockpit.spawn(["chown", owner, path], opts);
+    } else {
+        await cockpit.spawn(["mkdir", path], { err: "message" });
+    }
+}
+
+export const CreateDirectoryModal = ({ currentPath }: { currentPath: string }) => {
+    const Dialogs = useDialogs();
+    const [name, setName] = useState("");
+    const [nameError, setNameError] = useState<string | undefined>();
+    const [errorMessage, setErrorMessage] = useState<string | undefined>();
+    const [owner, setOwner] = useState<string | undefined>();
+    const createDirectory = () => {
+        const path = currentPath + name;
+        create_directory(path, owner).then(Dialogs.close, err => setErrorMessage(err.message));
+    };
+    const id = useId();
+    const { cwdInfo } = useFilesContext();
+
+    const candidates = [];
+    if (superuser.allowed && id && cwdInfo) {
+        candidates.push(...get_owner_candidates(id, cwdInfo));
+        if (owner === undefined) {
+            setOwner(candidates[0]);
+        }
+    }
+
+    return (
+        <Modal
+          position="top"
+          title={_("Create directory")}
+          isOpen
+          onClose={Dialogs.close}
+          variant={ModalVariant.small}
+          footer={
+              <>
+                  <Button
+                    variant="primary"
+                    onClick={createDirectory}
+                    isDisabled={errorMessage !== undefined ||
+                        nameError !== undefined ||
+                        id === null ||
+                        cwdInfo === null}
+                  >
+                      {_("Create")}
+                  </Button>
+                  <Button variant="link" onClick={Dialogs.close}>{_("Cancel")}</Button>
+              </>
+          }
+        >
+            <Stack>
+                {errorMessage !== undefined &&
+                <InlineNotification
+                  type="danger"
+                  text={errorMessage}
+                  isInline
+                />}
+                <Form
+                  isHorizontal onSubmit={e => {
+                      createDirectory();
+                      e.preventDefault();
+                      return false;
+                  }}
+                >
+                    <FormGroup fieldId="create-directory-input" label={_("Directory name")}>
+                        <TextInput
+                          validated={nameError ? "error" : "default"}
+                          value={name}
+                          onChange={(_, val) => {
+                              setNameError(check_name(val));
+                              setErrorMessage(undefined);
+                              setName(val);
+                          }}
+                          id="create-directory-input" autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+                        />
+                        <FormHelper fieldId="create-directory-input" helperTextInvalid={nameError} />
+                    </FormGroup>
+                    {candidates.length > 0 &&
+                        <FormGroup fieldId="create-directory-owner" label={_("Directory owner")}>
+                            <FormSelect
+                              id='create-directory-owner'
+                              value={owner}
+                              onChange={(_ev, val) => setOwner(val)}
+                            >
+                                {candidates.map(owner =>
+                                    <FormSelectOption
+                                      key={owner}
+                                      value={owner}
+                                      label={owner}
+                                    />)}
+                            </FormSelect>
+                        </FormGroup>}
+                </Form>
+            </Stack>
+        </Modal>
+    );
+};

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -42,6 +42,7 @@ import { superuser } from "superuser";
 
 import { map_permissions, inode_types, basename } from "./common";
 import { useFilesContext } from "./app";
+import { CreateDirectoryModal } from "./dialogs/mkdir";
 
 const _ = cockpit.gettext;
 
@@ -119,67 +120,6 @@ export const ConfirmDeletionDialog = ({
               text={errorMessage}
               isInline
             />}
-        </Modal>
-    );
-};
-
-const CreateDirectoryModal = ({ currentPath }) => {
-    const Dialogs = useDialogs();
-    const [name, setName] = useState("");
-    const [nameError, setNameError] = useState(null);
-    const [errorMessage, setErrorMessage] = useState(undefined);
-    const { cwdInfo } = useFilesContext();
-    const createDirectory = () => {
-        const path = currentPath + name;
-        cockpit.spawn(["mkdir", path], { superuser: "try", err: "message" })
-                .then(Dialogs.close, err => setErrorMessage(err.message));
-    };
-
-    return (
-        <Modal
-          position="top"
-          title={_("Create directory")}
-          isOpen
-          onClose={Dialogs.close}
-          variant={ModalVariant.small}
-          footer={
-              <>
-                  <Button
-                    variant="primary"
-                    onClick={createDirectory}
-                    isDisabled={errorMessage !== undefined || nameError !== null}
-                  >
-                      {_("Create")}
-                  </Button>
-                  <Button variant="link" onClick={Dialogs.close}>{_("Cancel")}</Button>
-              </>
-          }
-        >
-            <Stack>
-                {errorMessage !== undefined &&
-                <InlineNotification
-                  type="danger"
-                  text={errorMessage}
-                  isInline
-                />}
-                <Form
-                  isHorizontal onSubmit={e => {
-                      createDirectory();
-                      e.preventDefault();
-                      return false;
-                  }}
-                >
-                    <FormGroup fieldId="create-directory-input" label={_("Directory name")}>
-                        <TextInput
-                          validated={nameError ? "error" : "default"}
-                          value={name}
-                          onChange={(_, val) => setInputName(val, setName, setNameError, setErrorMessage, cwdInfo)}
-                          id="create-directory-input" autoFocus // eslint-disable-line jsx-a11y/no-autofocus
-                        />
-                        <FormHelper fieldId="create-directory-input" helperTextInvalid={nameError} />
-                    </FormGroup>
-                </Form>
-            </Stack>
         </Modal>
     );
 };

--- a/src/ownership.tsx
+++ b/src/ownership.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+
+import cockpit from 'cockpit';
+
+import { FileInfo } from './fsinfo';
+
+interface Id {
+    id: number;
+    name: string | null;
+}
+
+interface IdInfo {
+    uid: Id;
+    gid: Id;
+    groups: Id[];
+}
+
+function parse_id(content: string): Id {
+    const match = content.match(/^(\d+)\(([^)]+)\)$/);
+    if (!match) {
+        throw new Error(`invalid id ${content}`);
+    }
+
+    const id = Number(match[1]);
+    const name = match[2] === "unbound" ? null : match[2];
+
+    return { id, name };
+}
+
+export function useId(): IdInfo | null {
+    /* XXX This should be part of the cockpit UserInfo */
+
+    const [id, setId] = React.useState<IdInfo | null>(null);
+
+    React.useEffect(() => {
+        cockpit.spawn(['id'], { environ: ['LC_ALL=POSIX'] }).then(stdout => {
+            const fields: {[name: string]: string} = {};
+
+            for (const field of stdout.trim().split(' ')) {
+                const [name, content] = field.split('=', 2);
+                fields[name] = content;
+            }
+
+            try {
+                const uid = parse_id(fields.uid);
+                const gid = parse_id(fields.gid);
+                const groups = fields.groups?.split(',')?.map(parse_id) || [];
+                setId({ uid, gid, groups });
+            } catch (exc) {
+                console.log(`Failed to parse output of "id" command: ${stdout}: ${exc}`);
+            }
+        });
+    }, []);
+
+    return id;
+}
+
+// Determine the potential ownerships that a new item created in a particular
+// directory might have, in case we have admin access.  If superuser mode is
+// disabled, it's all a moot point, since we don't have any choice (in which
+// case this function should not be used).  This is very much a heuristic, and
+// might change in the future.
+export function get_owner_candidates(id: IdInfo, info: FileInfo) {
+    // In case the parent directory is setgid, we always override the group we
+    // create as, mirroring the usual POSIX behaviour.  There are other cases
+    // where the "BSD group semantics" come into play (like mount options) but
+    // we don't currently support those.  We might in the future, though...
+    const setgid = (info.group !== undefined && (info.mode || 0) & 0o2000) ? `${info.group}` : null;
+
+    // Set() is ordered: we insert options in the order of preference.
+    const candidates = new Set<string>();
+
+    // Most preferred option: create with the ownership of the parent
+    // directory.  Don't offer this if:
+    //   - the directory is a world-writable sticky (like /tmp)
+    //   - we don't know the ownership information of the parent
+    if (!info.mode || (info.mode & 0o1222) !== 0o1222) {
+        if (info.user !== undefined && info.group !== undefined) {
+            candidates.add(`${info.user}:${info.group}`);
+        }
+    }
+
+    // If we're authenticated as the superuser, we can do root:root as well.
+    candidates.add(`root:${setgid || 'root'}`);
+
+    // The last option is always available: create as the normal user.  In case
+    // of something inside of the user's home directory, this was probably the
+    // first option as well...
+    candidates.add(`${id.uid.name || id.uid.id}:${setgid || id.gid.name || id.gid.id}`);
+
+    return [...candidates];
+}

--- a/test/check-application
+++ b/test/check-application
@@ -34,6 +34,12 @@ class TestFiles(testlib.MachineCase):
     def stat(self, fmt: str, path: str) -> str:
         return self.machine.execute(['stat', f'--format={fmt}', path]).strip()
 
+    def assert_stat(self, fmt: str, path: str, expected: str) -> None:
+        self.assertEqual(self.stat(fmt, path), expected)
+
+    def assert_owner(self, path: str, owner: str) -> None:
+        self.assert_stat('%U:%G', path, owner)
+
     # TODO: move to testlib.py
     def press_special_key(self, name):
         args = {"type": "keyDown", "key": name}
@@ -480,7 +486,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_not_present("[data-item='delete1']")
         b.wait_not_present("[data-item='delete2']")
 
-    def testCreate(self):
+    def testCreateDirectory(self):
         b = self.browser
         m = self.machine
 
@@ -489,6 +495,7 @@ class TestFiles(testlib.MachineCase):
         # Create folder
         self.create_directory(b, "newdir")
         b.wait_visible("[data-item='newdir']")
+        self.assert_owner('/home/admin/newdir', 'admin:admin')
 
         # validation
         b.click("#dropdown-menu")
@@ -496,26 +503,24 @@ class TestFiles(testlib.MachineCase):
         b.set_input_text("#create-directory-input", "test")
         b.set_input_text("#create-directory-input", "")
         b.wait_visible("button.pf-m-primary:disabled")
-        b.wait_in_text("#create-directory-input-helper", "Name cannot be empty.")
+        b.wait_in_text("#create-directory-input-helper", "Directory name cannot be empty.")
 
         b.set_input_text("#create-directory-input", "a" * 256)
         b.wait_visible("button.pf-m-primary:disabled")
-        b.wait_in_text("#create-directory-input-helper", "Name too long.")
+        b.wait_in_text("#create-directory-input-helper", "Directory name too long.")
 
         b.set_input_text("#create-directory-input", "foo/bar")
         b.wait_visible("button.pf-m-primary:disabled")
-        b.wait_in_text("#create-directory-input-helper", "Name cannot include a /.")
+        b.wait_in_text("#create-directory-input-helper", "Directory name cannot include a /.")
 
         b.set_input_text("#create-directory-input", "test")
         b.wait_visible("button.pf-m-primary:not(:disabled)")
         b.click(".pf-v5-c-modal-box__footer button.pf-m-link")  # cancel
 
         # Creating folder with duplicate name should return an error
-        b.click("#dropdown-menu")
-        b.click("#create-item")
-        b.set_input_text("#create-directory-input", "newdir")
-        b.wait_in_text("#create-directory-input-helper", "File or directory already exists")
-        b.click(".pf-v5-c-modal-box__footer button.pf-m-link")  # cancel
+        self.create_directory(b, "newdir")
+        self.wait_modal_inline_alert(b, "mkdir: cannot create directory ‘/home/admin/newdir’: File exists")
+        b.click("div.pf-v5-c-modal-box__close button.pf-v5-c-button")
 
         # Creating folder with empty name should return an error
         self.create_directory(b, "")
@@ -532,6 +537,27 @@ class TestFiles(testlib.MachineCase):
         b.click("div.pf-v5-c-modal-box__close button.pf-v5-c-button")
         b.click(".breadcrumb-button:nth-of-type(3)")
         m.execute("sudo chattr -i /home/admin/newdir")
+
+        b.go("/files#/?path=/root")
+        b.wait_not_present(".pf-v5-c-empty-state")
+        self.addCleanup(m.execute, ['rm', '-rf', '/root/newdir'])
+        self.create_directory(b, "newdir")
+        b.wait_visible("[data-item='newdir']")
+        self.assert_owner('/root/newdir', 'root:root')
+
+        m.execute('useradd -m testuser')
+        b.go('/files#/?path=/home/testuser')
+        b.wait_not_present('.pf-v5-c-empty-state')
+        self.create_directory(b, 'newdir')
+        b.wait_visible("[data-item='newdir']")
+        self.assert_owner('/home/testuser', 'testuser:testuser')
+
+        b.go('/files#/?path=/tmp')
+        b.wait_not_present('.pf-v5-c-empty-state')
+        self.addCleanup(m.execute, ['rm', '-rf', '/tmp/newdir'])
+        self.create_directory(b, 'newdir')
+        b.wait_visible("[data-item='newdir']")
+        self.assert_owner('/tmp/newdir', 'root:root')
 
     def testContextMenu(self):
         b = self.browser

--- a/test/check-application
+++ b/test/check-application
@@ -31,6 +31,9 @@ class TestFiles(testlib.MachineCase):
         self.login_and_go("/files")
         self.browser.wait_not_present(".pf-c-empty-state")
 
+    def stat(self, fmt: str, path: str) -> str:
+        return self.machine.execute(['stat', f'--format={fmt}', path]).strip()
+
     # TODO: move to testlib.py
     def press_special_key(self, name):
         args = {"type": "keyDown", "key": name}
@@ -578,7 +581,7 @@ class TestFiles(testlib.MachineCase):
         m.execute("echo 'some content' > /home/admin/newfile")
         b.mouse("[data-item='newfile']", "contextmenu")
         b.click(".contextMenu button:contains('Download')")
-        size = int(m.execute("stat --format '%s' /home/admin/newfile").strip())
+        size = int(self.stat('%s', '/home/admin/newfile'))
         self.waitDownloadFile("newfile", size, "some content\n")
 
         # Delete button text should match item type: directory/file


### PR DESCRIPTION
If we have superuser capabilities, then add a drop-down list to the "Create directory" dialog with possible ownerships for the create directory.

By default we try to create the new directory with the same owner as the parent, but also have options for root:root or the user:group of the logged in user (if it is different from the parent directory).

The logic for determining the potential owners of newly created items is generic and might also be applied to things like upload, so keep it in its own file.

Also, move the dialog into a new file: src/dialogs/mkdirt.tsx. fileActions has become a bit too much of a catch-all.


Todo:
 - [x] better UI
 - [x] https://github.com/cockpit-project/cockpit/pull/20516 and sync
 - [x] tests for creating in various directories and ensuring "reasonable default"
