### PR TITLE
Allow sorting on size

### DIFF
--- a/src/files-card-body.jsx
+++ b/src/files-card-body.jsx
@@ -73,6 +73,12 @@ const compare = (sortBy) => {
                 ? -1
                 : 1)
             : compareFileType(a, b);
+    case "size":
+        return (a, b) => compareFileType(a, b) === 0
+            ? (a.size > b.size
+                ? -1
+                : 1)
+            : compareFileType(a, b) * -1;
     default:
         break;
     }

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -138,6 +138,7 @@ const ViewSelector = ({ isGrid, setIsGrid, sortBy, setSortBy }:
                 <SelectOption itemId="za">{_("Z-A")}</SelectOption>
                 <SelectOption itemId="last_modified">{_("Last modified")}</SelectOption>
                 <SelectOption itemId="first_modified">{_("First modified")}</SelectOption>
+                <SelectOption itemId="size">{_("Size")}</SelectOption>
             </SelectList>
         </Select>
     );


### PR DESCRIPTION
By default we sort files from large to small and then show folders.

* [ ] add tests

---

@garrett how do I change the sorting on size? The default is Big to small files and then folders

![image](https://github.com/cockpit-project/cockpit-files/assets/67428/9b74817b-88ae-4fb5-9583-a12198381193)

Do I have to click again on `size` to change the sorting to small -> big?

![image](https://github.com/cockpit-project/cockpit-files/assets/67428/e0f96728-e110-436e-a4d9-b447267d75fe)
