### PR TITLE
Useful listing table

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -63,78 +63,6 @@ button.breadcrumb-edit-cancel-button {
     grid-template-columns: repeat(auto-fill, minmax(var(--pf-v5-l-gallery--GridTemplateColumns--max), 1fr));
 }
 
-.directory-item, .file-item {
-    // Align icon and text in icon mode
-    .pf-v5-l-gallery & .pf-v5-c-card__header-main {
-        flex-direction: column;
-        align-items: center;
-        text-align: center;
-        gap: 0;
-    }
-
-    // Align icon and text in list mode
-    .ct-table & .pf-v5-c-card__header-main {
-        justify-content: start !important;
-        gap: var(--pf-v5-global--spacer--sm);
-    }
-
-    // Limit to 3 vertical lines and add ellipsis at the end when needed.
-    // (Sadly, there's no way to truncate in the middle, except via a PF
-    // component... but that doesn't allow wrapping and clamping line height.)
-    .pf-v5-c-card__title-text {
-        // Yes, all browsers support line-clamp with the webkit prefix. No
-        // browser supports it unprefixed. All browsers require a display of
-        // -webkit-box and -webkit-box-orient as well. It's one of the few
-        // prefixed attributes that's so well supported and still needed.
-        display: -webkit-box; /* stylelint-disable-line value-no-vendor-prefix */
-        -webkit-line-clamp: 3;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        overflow-wrap: anywhere;
-        // Wrapping should be more balanced (new; not supported everywhere yet)
-        text-wrap: balance;
-    }
-}
-
-.directory-item {
-    --icon-color: var(--pf-v5-global--link--Color--light);
-
-    &:is(:hover,.pf-m-selected) {
-        --icon-color: var(--pf-v5-global--link--Color);
-    }
-
-    .pf-v5-theme-dark & {
-        --icon-color: var(--pf-v5-global--link--Color--dark);
-    }
-
-    .pf-v5-theme-dark &:is(:hover,.pf-m-selected) {
-        --icon-color: var(--pf-v5-global--link--Color--dark--hover);
-    }
-}
-
-.file-item {
-    --icon-color: var(--pf-v5-global--palette--black-400);
-
-    &:is(:hover,.pf-m-selected) {
-        --icon-color: var(--pf-v5-global--palette--black-500);
-    }
-
-    .pf-v5-theme-dark & {
-        --icon-color: var(--pf-v5-global--palette--black-400);
-    }
-
-    .pf-v5-theme-dark &:is(:hover,.pf-m-selected) {
-        --icon-color: var(--pf-v5-global--palette--black-300);
-    }
-}
-
-.directory-item, .file-item {
-     svg > path {
-        fill: var(--icon-color);
-    }
-}
-
 .sidebar-card {
     background: inherit;
     box-shadow: none;
@@ -147,10 +75,6 @@ button.breadcrumb-edit-cancel-button {
 
 #description-list-sidebar {
     margin-block-end: 1rem;
-}
-
-.item-button {
-    color: var(--pf-v5-global--Color--200);
 }
 
 // Improve header layout and wrap header text

--- a/src/files-card-body.scss
+++ b/src/files-card-body.scss
@@ -1,0 +1,194 @@
+.fileview {
+    .row-selected {
+      background-color: var(--pf-v5-c-card--m-selectable--m-selected--BackgroundColor);
+    }
+
+    --icon-size: 32px;
+    border-collapse: collapse;
+    inline-size: 100%;
+    margin: var(--pf-v5-global--spacer--sm);
+    line-height: var(--pf-v5-global--LineHeight--md);
+    font-family: var(--pf-v5-global--FontFamily--text);
+    font-size: var(--pf-v5-global--FontSize--md);
+    block-size: 100%;
+    overflow: auto;
+
+    th {
+        text-align: start;
+    }
+
+    tr {
+        --color-folder: var(--pf-v5-global--primary-color--100);
+        --color-icon: var(--pf-v5-global--Color--400);
+
+        &:focus,
+        &:focus-within {
+            --color-folder: var(--pf-v5-global--primary-color--200);
+            --color-icon: var(--pf-v5-global--Color--300);
+        }
+    }
+
+    a:focus:not(:focus-visible) {
+        outline: none;
+    }
+
+    a:focus-within {
+        outline-offset: var(--pf-v5-global--spacer--sm);
+        border-radius: var(--pf-v5-global--BorderWidth--md);
+        outline-style: dashed;
+    }
+
+    .item-name {
+        // Bump up the font size to standard for the filenames
+        a {
+            font-size: var(--pf-v5-global--FontSize--md);
+        }
+
+        a::before {
+            /* content-visibility: auto; */
+            aspect-ratio: 1;
+            background-color: var(--color-icon);
+            block-size: var(--icon-size);
+            content: '';
+            mask-repeat: no-repeat;
+            mask-position: center;
+            mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1536 1792"><path d="M1468 380c37 37 68 111 68 164v1152c0 53-43 96-96 96H96c-53 0-96-43-96-96V96C0 43 43 0 96 0h896c53 0 127 31 164 68zm-444-244v376h376c-6-17-15-34-22-41l-313-313c-7-7-24-16-41-22zm384 1528V640H992c-53 0-96-43-96-96V128H128v1536z"/></svg>');
+        }
+    }
+
+    tr.folder {
+        .item-name a::before {
+            background-color: var(--color-folder);
+            mask-image: url('data:image/svg+xml,<svg class="pf-v5-svg" viewBox="0 0 512 512" fill="currentColor" aria-hidden="true" role="img" width="100%" height="100%" color="var(--pf-v5-global--Color--100)" xmlns="http://www.w3.org/2000/svg"><path d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"></path></svg>');
+        }
+    }
+
+    a:not(:hover, :focus) {
+        color: inherit;
+    }
+
+    // Propogate the hovering via variables to the link and cursor
+    tr:hover {
+        --pf-v5-global--link--Color: var(--pf-v5-global--link--Color--hover);
+        --pf-v5-global--link--TextDecoration: var(--pf-v5-global--link--TextDecoration--hover);
+        cursor: pointer;
+    }
+
+    &.view-details .item-name a::before {
+        display: inline-block;
+        margin-inline-end: var(--pf-v5-global--spacer--sm);
+        // FIXME: Figure out why there's an offset
+        transform: translateY(3px);
+    }
+
+    &.view-grid .item-name a {
+        display: block;
+
+        &::before {
+            display: block;
+            margin-inline: auto;
+            margin-block-end: var(--pf-v5-global--spacer--sm);
+        }
+    }
+
+    &.view-details {
+        --icon-size: 16px;
+        inline-size: calc(100% - var(--pf-v5-global--spacer--md));
+        margin-block: var(--pf-v5-global--spacer--sm);
+        margin-inline: auto;
+
+        tbody tr {
+            border-block: 1px solid var(--pf-v5-global--BorderColor--100);
+        }
+
+        tbody > tr:hover {
+            background-color: var(--pf-v5-global--BackgroundColor--200);
+        }
+
+        th, td {
+            padding: var(--pf-v5-global--spacer--sm);
+            border-block-start: none;
+        }
+
+        .col-size, .item-size,
+        .col-date, .item-date {
+            inline-size: 12ch;
+            text-align: end;
+        }
+
+        // Remove the extra padding on the end of the column and button, as the icon has padding already
+        .col-size, .col-date {
+            &, .pf-v5-c-table__button {
+                padding-inline-end: 0;
+            }
+
+            .pf-v5-c-table__button {
+                inline-size: 100%;
+                justify-content: end;
+            }
+        }
+    }
+
+    &.view-grid {
+        --icon-size: 64px;
+        display: contents;
+
+        thead {
+            display: none;
+        }
+
+        tbody {
+            align-items: start;
+            display: grid;
+            // As we're using justify-content: space-between, this is the minimum gap horizontally;
+            gap: var(--pf-v5-global--spacer--sm);
+            grid-template-columns: repeat(auto-fill, minmax(8rem,1fr));
+            justify-content: space-between;
+            margin: var(--pf-v5-global--spacer--sm);
+        }
+
+        tr {
+            display: block;
+            // Override default PF padding
+            padding: 0;
+
+            td {
+                display: block;
+                text-align: center;
+                word-break: break-all;
+                // Override default PF padding
+                padding: 0;
+
+                a {
+                    padding: var(--pf-v5-global--spacer--sm);
+                }
+
+                &:not(:last-child) a {
+                    padding-block-end: 0;
+                }
+
+                + td {
+                    padding-block-end: var(--pf-v5-global--spacer--sm);
+                }
+            }
+
+            .item-num {
+                display: none;
+            }
+
+            .item-size {
+                font-size: 0.8em;
+                color: #888;
+            }
+
+            .item-date {
+                display: none;
+            }
+
+            &:hover {
+                background-color: var(--pf-v5-global--BackgroundColor--200);
+                outline: 1px solid var(--pf-v5-global--BackgroundColor--300);
+            }
+        }
+    }
+}

--- a/src/files-folder-view.tsx
+++ b/src/files-folder-view.tsx
@@ -65,6 +65,7 @@ export const FilesFolderView = ({
               path={path}
               isGrid={isGrid}
               sortBy={sortBy}
+              setSortBy={setSortBy}
               selected={selected}
               setSelected={setSelected}
               loadingFiles={loadingFiles}

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -35,11 +35,55 @@ import {
     TextContent,
     TextVariants
 } from "@patternfly/react-core";
+import { SortByDirection } from '@patternfly/react-table';
 import { GripVerticalIcon, ListIcon } from "@patternfly/react-icons";
 
 import { UploadButton } from "./upload-button";
 
 const _ = cockpit.gettext;
+
+export const filterColumns = [
+    {
+        title: _("Name"),
+        [SortByDirection.asc]: {
+            itemId: "az",
+            label: _("A-Z"),
+        },
+        [SortByDirection.desc]: {
+            itemId: "za",
+            label: _("Z-A"),
+        }
+    },
+    {
+        title: _("Size"),
+        [SortByDirection.asc]: {
+            itemId: "largest_size",
+            label: _("Largest size"),
+        },
+        [SortByDirection.desc]: {
+            itemId: "smallest_size",
+            label: _("Smallest size"),
+        }
+    },
+    {
+        title: _("Modified"),
+        [SortByDirection.asc]: {
+            itemId: "first_modified",
+            label: _("First modified"),
+        },
+        [SortByDirection.desc]: {
+            itemId: "last_modified",
+            label: _("Last modified"),
+        },
+    },
+];
+
+// { itemId: [index, sortdirection] }
+export const filterColumnMapping = filterColumns.reduce((a, v, i) => ({
+    ...a,
+    [v[SortByDirection.asc].itemId]: [i, SortByDirection.asc],
+    [v[SortByDirection.desc].itemId]: [i, SortByDirection.desc]
+}), {});
 
 export const FilesCardHeader = ({
     currentFilter,
@@ -135,10 +179,15 @@ const ViewSelector = ({ isGrid, setIsGrid, sortBy, setSortBy }:
           )}
         >
             <SelectList>
-                <SelectOption itemId="az">{_("A-Z")}</SelectOption>
-                <SelectOption itemId="za">{_("Z-A")}</SelectOption>
-                <SelectOption itemId="last_modified">{_("Last modified")}</SelectOption>
-                <SelectOption itemId="first_modified">{_("First modified")}</SelectOption>
+                {filterColumns.map((column, rowIndex) =>
+                    <React.Fragment key={rowIndex}>
+                        <SelectOption itemId={column[SortByDirection.asc].itemId}>
+                            {column[SortByDirection.asc].label}
+                        </SelectOption>
+                        <SelectOption itemId={column[SortByDirection.desc].itemId}>
+                            {column[SortByDirection.desc].label}
+                        </SelectOption>
+                    </React.Fragment>)}
             </SelectList>
         </Select>
     );

--- a/test/check-application
+++ b/test/check-application
@@ -122,7 +122,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_in_text("#description-list-last-modified ", "Jan 1, 2022, 12:00 PM")
 
         # clicking empty space resets sidebar
-        b.click("#folder-view")
+        b.click("#folder-view tbody")
         b.wait_in_text("#sidebar-card-header", "admin")
 
         # folder information doesn't contain size
@@ -134,13 +134,13 @@ class TestFiles(testlib.MachineCase):
         b.wait_text("#description-list-last-modified dd", "Jan 1, 2022, 12:00 PM")
 
         # filtering works
-        self.browser.wait_js_cond("ph_count('#folder-view > .pf-v5-c-card') > 1")
+        self.browser.wait_js_cond("ph_count('#folder-view tbody tr') > 1")
         b.set_input_text("input[placeholder='Filter directory']", "newfile")
-        self.browser.wait_js_cond("ph_count('#folder-view > .pf-v5-c-card') == 1")
+        self.browser.wait_js_cond("ph_count('#folder-view tbody tr') == 1")
 
         # no results when filtering
         b.set_input_text("input[placeholder='Filter directory']", "absolutelynothing")
-        self.browser.wait_js_cond("ph_count('#folder-view > .pf-v5-c-card') == 0")
+        self.browser.wait_js_cond("ph_count('#folder-view tbody tr') == 0")
         b.wait_text(".pf-v5-c-empty-state__body", "No matching results")
 
         # clear using input button
@@ -224,7 +224,7 @@ class TestFiles(testlib.MachineCase):
         m.execute("ln -s /tmp /home/admin/tmplink")
         b.click("[data-item='tmplink']")
         b.wait_in_text("#sidebar-card-header", "symbolic link to /tmp")
-        b.mouse(".directory-item[data-item='tmplink']", "dblclick")
+        b.mouse("[data-item='tmplink']", "dblclick")
         b.wait_not_present("[data-item='tmplink']")
         b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "tmplink")
         b.go("/files#/?path=/home/admin")
@@ -262,8 +262,8 @@ class TestFiles(testlib.MachineCase):
         b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "newdir2")
         b.eval_js("window.history.forward()")
         # Switching navigation resets selected state
-        b.wait_visible("#card-item-admindir")
-        b.wait_not_present("#card-item-admindir.pf-m-selected")
+        b.wait_visible("[data-item='admin']")
+        b.wait_not_present("[data-item='admin'].row-selected")
         b.wait_in_text("#sidebar-card-header", "home")
         b.wait_not_present("[data-item='newdir']")
         b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "home")
@@ -351,46 +351,61 @@ class TestFiles(testlib.MachineCase):
 
         # Default sort is A-Z
         # Alphabet sorts should be case insensetive
-        b.wait_text(".item-button:nth-of-type(1)", "aaa")
-        b.wait_text(".item-button:nth-of-type(2)", "BBB")
-        b.wait_text(".item-button:nth-of-type(3)", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "ccc")
 
         # Sort by reverse alphabet
         b.select_PF5("#sort-menu-toggle", "#sort-menu", "Z-A")
         # Alphabet sorts should be case insensetive
-        b.wait_text(".item-button:nth-of-type(1)", "ccc")
-        b.wait_text(".item-button:nth-of-type(2)", "BBB")
-        b.wait_text(".item-button:nth-of-type(3)", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "aaa")
 
         # Sort by last modified
         b.select_PF5("#sort-menu-toggle", "#sort-menu", "Last modified")
-        b.wait_text(".item-button:nth-of-type(1)", "ccc")
-        b.wait_text(".item-button:nth-of-type(2)", "aaa")
-        b.wait_text(".item-button:nth-of-type(3)", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "BBB")
 
         # Update content of files
         m.execute('echo "update" > /home/admin/aaa')
 
-        b.wait_text(".item-button:nth-of-type(1)", "aaa")
-        b.wait_text(".item-button:nth-of-type(2)", "ccc")
-        b.wait_text(".item-button:nth-of-type(3)", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "BBB")
 
         # Sort by first modified
         b.select_PF5("#sort-menu-toggle", "#sort-menu", "First modified")
-        b.wait_text(".item-button:nth-of-type(1)", "BBB")
-        b.wait_text(".item-button:nth-of-type(2)", "ccc")
-        b.wait_text(".item-button:nth-of-type(3)", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "aaa")
 
         # Sort option should be saved in localStorage
         b.select_PF5("#sort-menu-toggle", "#sort-menu", "Z-A")
-        b.wait_text(".item-button:nth-of-type(1)", "ccc")
-        b.wait_text(".item-button:nth-of-type(2)", "BBB")
-        b.wait_text(".item-button:nth-of-type(3)", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "aaa")
         b.reload()
         b.enter_page("/files")
-        b.wait_text(".item-button:nth-of-type(1)", "ccc")
-        b.wait_text(".item-button:nth-of-type(2)", "BBB")
-        b.wait_text(".item-button:nth-of-type(3)", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "aaa")
+
+        # Sort on size
+        m.execute("""
+            echo 'lol' > /home/admin/aaa
+            truncate -s 10M /home/admin/BBB
+        """)
+        b.select_PF5("#sort-menu-toggle", "#sort-menu", "Largest size")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "ccc")
+
+        b.select_PF5("#sort-menu-toggle", "#sort-menu", "Smallest size")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "BBB")
 
         m.execute("""
             ln -s /tmp /home/admin/ddd
@@ -403,12 +418,12 @@ class TestFiles(testlib.MachineCase):
 
         # Directories are sorted first
         b.select_PF5("#sort-menu-toggle", "#sort-menu", "A-Z")
-        b.wait_text(".item-button:nth-of-type(1)", "ddd")
-        b.wait_text(".item-button:nth-of-type(2)", "eee")
-        b.wait_text(".item-button:nth-of-type(3)", "Eee")
-        b.wait_text(".item-button:nth-of-type(4)", "aaa")
-        b.wait_text(".item-button:nth-of-type(5)", "BBB")
-        b.wait_text(".item-button:nth-of-type(6)", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "ddd")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "Eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "ccc")
 
     def testDelete(self):
         b = self.browser
@@ -467,8 +482,8 @@ class TestFiles(testlib.MachineCase):
         m.execute("touch /home/admin/delete1 /home/admin/delete2")
         b.click("[data-item='delete1']")
         b.mouse("[data-item='delete2']", "click", ctrlKey=True)
-        b.wait_visible("[data-item='delete1'].pf-m-selected")
-        b.wait_visible("[data-item='delete2'].pf-m-selected")
+        b.wait_visible("[data-item='delete1'].row-selected")
+        b.wait_visible("[data-item='delete2'].row-selected")
         self.press_special_key("Delete")
         b.wait_in_text("h1.pf-v5-c-modal-box__title", "Delete 2 items?")
         b.click("button.pf-m-danger")
@@ -538,7 +553,7 @@ class TestFiles(testlib.MachineCase):
         b.allow_download()
 
         # Create folder from context menu
-        b.mouse("#folder-view", "contextmenu")
+        b.mouse("#files-card-parent", "contextmenu")
         b.click(".contextMenu button:contains('Create directory')")
         b.set_input_text("#create-directory-input", "newdir")
         b.click("button.pf-m-primary")
@@ -546,7 +561,7 @@ class TestFiles(testlib.MachineCase):
 
         # Opening context menu from empty space deselects item
         b.click("[data-item='newdir']")
-        b.mouse("#folder-view", "contextmenu")
+        b.mouse("#files-card-parent tbody", "contextmenu")
         b.click(".contextMenu button:contains('Create directory')")
         b.set_input_text("#create-directory-input", "newdir2")
         b.click("button.pf-m-primary")
@@ -763,7 +778,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_not_present(".pf-v5-c-empty-state")
 
         # Via contextmenu
-        b.mouse("#folder-view", "contextmenu")
+        b.mouse("#files-card-parent", "contextmenu")
         b.click(".contextMenu button:contains('Edit permissions')")
         b.wait_in_text(".pf-v5-c-modal-box__title-text", "testdir")
         b.select_from_dropdown("#edit-permissions-owner-access", "6")
@@ -848,27 +863,27 @@ class TestFiles(testlib.MachineCase):
         m.execute("touch /home/admin/file1 && touch /home/admin/file2")
         b.click("[data-item='file1']")
         b.mouse("[data-item='file2']", "click", ctrlKey=True)
-        b.wait_visible("[data-item='file1'].pf-m-selected")
-        b.wait_visible("[data-item='file2'].pf-m-selected")
+        b.wait_visible("[data-item='file1'].row-selected")
+        b.wait_visible("[data-item='file2'].row-selected")
         b.wait_text("#sidebar-card-header", "admin2 items selected")
 
         b.mouse("[data-item='file2']", "click", ctrlKey=True)
-        b.wait_visible("[data-item='file1'].pf-m-selected")
-        b.wait_not_present("[data-item='file2'].pf-m-selected")
+        b.wait_visible("[data-item='file1'].row-selected")
+        b.wait_not_present("[data-item='file2'].row-selected")
         b.wait_text("#sidebar-card-header", "file1empty")
 
         b.mouse("[data-item='file1']", "click", ctrlKey=True)
-        b.wait_not_present("[data-item='file1'].pf-m-selected")
+        b.wait_not_present("[data-item='file1'].row-selected")
         b.wait_in_text("#sidebar-card-header", "admin")
 
         # Control-clicking when nothing is selected should select item normally
         b.mouse("[data-item='file1']", "click", ctrlKey=True)
-        b.wait_visible("[data-item='file1'].pf-m-selected")
+        b.wait_visible("[data-item='file1'].row-selected")
         b.wait_text("#sidebar-card-header", "file1empty")
 
         # Check context menu
         b.mouse("[data-item='file2']", "click", ctrlKey=True)
-        b.wait_visible("[data-item='file2'].pf-m-selected")
+        b.wait_visible("[data-item='file2'].row-selected")
         b.wait_text("#sidebar-card-header", "admin2 items selected")
         b.mouse("[data-item='file1']", "contextmenu")
         b.wait_in_text(".contextMenu li:nth-child(2) button", "Delete")
@@ -904,28 +919,28 @@ class TestFiles(testlib.MachineCase):
         b.eval_js("window.focus()")
 
         b.click("[data-item='file0']")
-        b.wait_visible("[data-item='file0'].pf-m-selected")
+        b.wait_visible("[data-item='file0'].row-selected")
 
         self.press_special_key("ArrowRight")
-        b.wait_visible("[data-item='file1'].pf-m-selected")
+        b.wait_visible("[data-item='file1'].row-selected")
         self.press_special_key("ArrowLeft")
-        b.wait_visible("[data-item='file0'].pf-m-selected")
+        b.wait_visible("[data-item='file0'].row-selected")
 
         # Up / Down depends on the layout, this is tested on mobile where the
         # width is two cards.
         b.set_layout("mobile")
         b.click("[data-item='file0']")
-        b.wait_visible("[data-item='file0'].pf-m-selected")
+        b.wait_visible("[data-item='file0'].row-selected")
 
         self.press_special_key("ArrowDown")
-        b.wait_visible("[data-item='file2'].pf-m-selected")
+        b.wait_visible("[data-item='file2'].row-selected")
         self.press_special_key("ArrowUp")
-        b.wait_visible("[data-item='file0'].pf-m-selected")
+        b.wait_visible("[data-item='file0'].row-selected")
 
         m.execute("mkdir /home/admin/foo")
         b.click("[data-item='foo']")
 
-        b.wait_visible("[data-item='foo'].pf-m-selected")
+        b.wait_visible("[data-item='foo'].row-selected")
         self.press_special_key("Enter")
         b.wait_text(".breadcrumb-button:nth-of-type(5)", "foo")
 


### PR DESCRIPTION
![image](https://github.com/cockpit-project/cockpit-files/assets/67428/184dfe23-d09d-43ac-881a-67ed4b7e7f6b)


* [x] Make selectable visually work `.selected-class-thing + td { background: var(--pf-v5--theBackGroundColor); }
`
* [x] Stop using a Card in the first column, `<Icon isInline><p>File or dir</p>` instead
* [x] Make the contextmenu and selecting event handlers work
* [x] Make everything sortable
* [x] Stretch goal, combine both views into one as per https://garrett.github.io/cockpit-mockweb/navigator/grid#

## Re-useable table approach issues

* [ ] Refactor / clean up render function
* [x] Size header is not allowed with content
![image](https://github.com/cockpit-project/cockpit-files/assets/67428/ff1bd590-a574-4572-9b10-6251ff39665b)
* [x] Directory is empty twice
![image](https://github.com/cockpit-project/cockpit-files/assets/67428/51927039-8522-43a9-9790-b4035fea092e)
* [x] Too much spacing when there three items
![image](https://github.com/cockpit-project/cockpit-files/assets/67428/df8e3ad4-f420-44b8-9830-016280f6b1c6)
* [x] wrong icon for folders
* [x] Icon view not really centered
![image](https://github.com/cockpit-project/cockpit-files/assets/67428/75950a16-4a9d-4be7-b5c5-497a75f9395a)
* [x] Icon not centered / wrongly aligned
![image](https://github.com/cockpit-project/cockpit-files/assets/67428/a0b10c56-27e5-4afb-801d-79a238eae82b)
* [x] General text/font


## Follow up

* [ ] More useful dates? "Yesterday at 12:00" instead?
* [ ] Update & Merge the PF update PR as we no longer use a <Card> which blocked us from updating
* [ ] Scrollbar position wrong
![image](https://github.com/cockpit-project/cockpit-files/assets/67428/c4b9e0fb-7955-4702-a01a-1575f0a8ac21)
* [ ] Table should take the full height when available.
![image](https://github.com/cockpit-project/cockpit-files/assets/67428/5f4eee79-f027-408c-9519-60a81b903097)
`.pf-v5-c-sidebar__main, .pf-v5-c-sidebar__content, .pf-v5-c-card { height: 100%; }`
