### PR TITLE
Editing the path of the root dir should show / in the input

### DIFF
--- a/src/files-breadcrumbs.tsx
+++ b/src/files-breadcrumbs.tsx
@@ -74,7 +74,7 @@ export function FilesBreadcrumbs({ path, showHidden, setShowHidden }: { path: st
 
     const enableEditMode = () => {
         setEditMode(true);
-        setNewPath(path.join("/"));
+        setNewPath(path.join("/") || "/");
     };
 
     const changePath = () => {

--- a/test/check-application
+++ b/test/check-application
@@ -321,6 +321,16 @@ class TestFiles(testlib.MachineCase):
         b.click(edit_button)
         b.wait_visible(path_input)
         b.wait_val(path_input, "/var")
+        b.click(cancel_button)
+
+        # Editing / shows / in the input
+        b.click(edit_button)
+        b.set_input_text(path_input, "/")
+        b.click(apply_button)
+        b.wait_text("button.pf-m-disabled.breadcrumb-button + p", "/")
+        b.click(edit_button)
+        b.wait_val(path_input, "/")
+        b.click(cancel_button)
 
     def testSorting(self):
         b = self.browser


### PR DESCRIPTION
When editing the path and we are at the root directory the path in the input should resemble `/`. The path is stored as an array so join('/') gives "" instead of `/`. Later we want the path to on longer be an array but the real full path.