### PR TITLE
packaging: bump Cockpit requirement for send-acks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,10 +179,17 @@ VM_DEPENDS = $(COCKPIT_WHEEL)
 VM_CUSTOMIZE_FLAGS = --install $(COCKPIT_WHEEL)
 endif
 
+# HACK: temporary bump Cockpit on Debian-testing to get > 316
+ifeq ("$(TEST_OS)","debian-testing")
+VM_CUSTOMIZE_FLAGS = --run-command "apt update && apt-get install -y -t unstable cockpit"
+else
+VM_CUSTOMIZE_FLAGS = --no-network
+endif
+
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed
 $(VM_IMAGE): $(TARFILE) $(NODE_CACHE) packaging/arch/PKGBUILD bots test/vm.install $(VM_DEPENDS)
-	bots/image-customize --no-network --fresh \
+	bots/image-customize --fresh \
 		$(VM_CUSTOMIZE_FLAGS) \
 		--upload $(NODE_CACHE):/var/tmp/ --build $(TARFILE) \
 		--script $(CURDIR)/test/vm.install $(TEST_OS)

--- a/packaging/arch/PKGBUILD.in
+++ b/packaging/arch/PKGBUILD.in
@@ -5,7 +5,7 @@ pkgdesc='A filesystem browser for Cockpit'
 arch=('any')
 url='https://github.com/cockpit-project/cockpit-files'
 license=(LGPL)
-depends=("cockpit>=310.1")
+depends=("cockpit>=316")
 source=("SOURCE")
 sha256sums=('SKIP')
 

--- a/packaging/cockpit-files.spec.in
+++ b/packaging/cockpit-files.spec.in
@@ -16,7 +16,7 @@ BuildRequires: gettext
 BuildRequires: libappstream-glib-devel
 %endif
 
-Requires: cockpit-bridge >= 310
+Requires: cockpit-bridge >= 316
 
 %{NPM_PROVIDES}
 

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -15,7 +15,7 @@ Package: cockpit-files
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends},
-         cockpit-bridge (>= 310.1),
+         cockpit-bridge (>= 316),
 Description: A filesystem browser for Cockpit
  The Cockpit Web Console enables users to administer GNU/Linux servers using a
  web browser.


### PR DESCRIPTION
The fsreplace1 send-acks feature was added in 316.