### PR TITLE
sidebar: Headers should be above in a limited space

### DIFF
--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -167,7 +167,7 @@ export const SidebarPanelDetails = ({
             </CardHeader>
             {selected.length === 1 &&
             <CardBody>
-                <DescriptionList isHorizontal id="description-list-sidebar">
+                <DescriptionList id="description-list-sidebar">
                     {getDescriptionListItems(selected[0]).map((item, index) => (
                         <DescriptionListGroup key={item.id} id={item.id}>
                             <DescriptionListTerm>{item.label}</DescriptionListTerm>


### PR DESCRIPTION
This is a simple fix, as there isn't enough room for the sidebar to have labels on the side. This moves the labels in the list to the top and therefore doesn't make the sidebar always grow when something is selected (vs. not).

The mockups had labels on the top; I think having it on the side was an oversight and copied from much of the rest of Cockpit with labels on the side... there just isn't enough room for it here.