### PR TITLE
Makefile: use `XZ_OPT=-0` for `make vm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ endif
 
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed
+$(VM_IMAGE): export XZ_OPT=-0
 $(VM_IMAGE): $(TARFILE) $(NODE_CACHE) packaging/arch/PKGBUILD bots test/vm.install $(VM_DEPENDS)
 	bots/image-customize --fresh \
 		$(VM_CUSTOMIZE_FLAGS) \


### PR DESCRIPTION
...and make `make check` go via `make vm` so that it benefits as well.

This shaves quite some seconds off of image building (42s instead of 1m36s).  Most of that comes from compressing node_modules/ which seems like the obvious candidate to get rid of, but it's required by the build.  We could work around that, but it would involve some deeper hacks, so let's make the easy change, instead.