### PR TITLE
Correctly handle symlinks to `.` and `..`

### DIFF
--- a/src/fsinfo.ts
+++ b/src/fsinfo.ts
@@ -105,6 +105,10 @@ export function fsinfo(path: string, attrs: string[], options?: cockpit.JsonObje
                 return entry;
             if (target === '.')
                 return self.state.info;
+            // HACK: fsinfo should return this, but doesn't.
+            // We know we only need `.type`, so hardcode it.
+            if (target === '..')
+                return { type: 'dir' };
             entry = entries[target] ?? targets[target] ?? null;
         }
         return null; // ELOOP

--- a/src/fsinfo.ts
+++ b/src/fsinfo.ts
@@ -103,6 +103,8 @@ export function fsinfo(path: string, attrs: string[], options?: cockpit.JsonObje
             const target = entry?.target;
             if (!target)
                 return entry;
+            if (target === '.')
+                return self.state.info;
             entry = entries[target] ?? targets[target] ?? null;
         }
         return null; // ELOOP

--- a/test/check-application
+++ b/test/check-application
@@ -105,6 +105,10 @@ class TestFiles(testlib.MachineCase):
         b.wait_visible("[data-item='not-hidden']")
         b.wait_not_present("[data-item='.hiddenfile']")
 
+        # Symlink to `.` works and gets shown as directory
+        m.execute("ln -sf . /home/admin/dot")
+        b.wait_visible("[data-item='dot'].symlink.folder")
+
         # file sidebar information
         b.click("[data-item='newfile']")
         b.wait_text("#sidebar-card-header", "newfileempty")

--- a/test/check-application
+++ b/test/check-application
@@ -105,9 +105,11 @@ class TestFiles(testlib.MachineCase):
         b.wait_visible("[data-item='not-hidden']")
         b.wait_not_present("[data-item='.hiddenfile']")
 
-        # Symlink to `.` works and gets shown as directory
+        # Symlink to `.` and `..` work and get shown as directories
         m.execute("ln -sf . /home/admin/dot")
         b.wait_visible("[data-item='dot'].symlink.folder")
+        m.execute("ln -sf .. /home/admin/dotdot")
+        b.wait_visible("[data-item='dotdot'].symlink.folder")
 
         # file sidebar information
         b.click("[data-item='newfile']")


### PR DESCRIPTION
The `.` is probably best considered a bug in the `fsinfo` client code, but the `..` needs to be handled by the channel.  We can add a workaround to the client for `..` anyway, though.