### PR TITLE
Use tabular-nums everywhere in Files

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,7 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
     <script type="text/javascript" src="po.js"></script>
 </head>
 
-<body class="pf-m-redhat-font">
+<body class="pf-m-redhat-font pf-v5-m-tabular-nums">
     <div class="ct-page-fill" id="app"></div>
 </body>
 </html>

--- a/src/upload-button.tsx
+++ b/src/upload-button.tsx
@@ -312,7 +312,7 @@ export const UploadButton = ({
                           <Flex className="upload-progress-flex" flexWrap={{ default: 'nowrap' }}>
                               <Progress
                                 key={file.file.name}
-                                className={`upload-progress-${index} upload-progress pf-v5-m-tabular-nums`}
+                                className={`upload-progress-${index} upload-progress`}
                                 value={file.progress}
                                 title={file.file.name}
                                 max={file.file.size}


### PR DESCRIPTION
We apply this to the body of all our Cockpit pages and want to use them by default.

---

Doesn't resolve the size listing issue but this is generally what we want by default.