### PR TITLE
Makefile: switch to node_modules/ as submodule

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,82 @@
+name: update node_modules
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+
+jobs:
+  dependabot:
+    environment: npm-update
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
+    # 22.04's podman has issues with piping and causes tar errors
+    runs-on: ubuntu-20.04
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'node_modules') }}
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
+      - name: Clear node_modules label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'node_modules'
+              });
+            } catch (e) {
+              if (e.name == 'HttpError' && e.status == 404) {
+                /* expected: 404 if label is unset */
+              } else {
+                throw e;
+              }
+            }
+
+      - name: Update node_modules for package.json changes
+        run: |
+          make tools/node-modules
+          git config --global user.name "GitHub Workflow"
+          git config --global user.email "cockpituous@cockpit-project.org"
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.NODE_CACHE_DEPLOY_KEY }}'
+          ./tools/node-modules install
+          ./tools/node-modules push
+          git add node_modules
+          ssh-add -D
+          ssh-agent -k
+
+      - name: Clear [no-test] prefix from PR title
+        if: ${{ contains(github.event.pull_request.title, '[no-test]') }}
+        uses: actions/github-script@v7
+        env:
+          TITLE: '${{ github.event.pull_request.title }}'
+        with:
+          script: |
+            const title = process.env['TITLE'].replace(/\[no-test\]\W+ /, '')
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              title,
+            });
+
+      - name: Force push node_modules update
+        run: |
+          # Dependabot prefixes the commit with [no-test] which we don't want to keep in the commit
+          title=$(git show --pretty="%s" -s | sed -E "s/\[no-test\]\W+ //")
+          body=$(git show -s --pretty="%b")
+          git commit --amend -m "${title}" -m "${body}" --no-edit node_modules
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.SELF_DEPLOY_KEY }}'
+          git push --force 'git@github.com:${{ github.repository }}' '${{ github.head_ref }}'
+          ssh-add -D
+          ssh-agent -k

--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -1,0 +1,66 @@
+name: repository
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  check:
+    name: Protection checks
+    # 22.04's podman has issues with piping and causes tar errors
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
+    env:
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
+    steps:
+      - name: Clone target branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch PR commits
+        run: git fetch origin "${BASE_SHA}" "${HEAD_SHA}"
+
+      - name: Clear .github-changes label
+        if: ${{ !endsWith(github.event.action, 'labeled') }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: '.github-changes'
+              });
+            } catch (e) {
+              if (e.name == 'HttpError' && e.status == 404) {
+                /* expected: 404 if label is unset */
+              } else {
+                throw e;
+              }
+            }
+
+      - name: Check for .github changes
+        # We want to run this check any time the .github-changes label is not
+        # set, which needs to include the case where we just unset it above.
+        if: ${{ !endsWith(github.event.action, 'labeled') ||
+                !contains(github.event.pull_request.labels.*.name, '.github-changes') }}
+        run: |
+          set -x
+          git log --full-history --exit-code --patch "${HEAD_SHA}" --not "${BASE_SHA}" -- .github >&2
+
+      - name: Check for node_modules availability and package.json consistency
+        run: |
+          # Make tools/node-modules available
+          make tools/node-modules
+          # for each commit in the PR which modifies package.json or node_modules...
+          for commit in $(git log --reverse --full-history --format=%H \
+                              "${HEAD_SHA}" --not "${BASE_SHA}" -- package.json node_modules); do
+              # ... check that package.json and node_modules/.package.json are in sync
+              tools/node-modules verify "${commit}"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@
 /dist/
 /package-lock.json
 /pkg/
-/node_modules/
 /tmp/
 /tools/
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "node_modules"]
+	path = node_modules
+	url = https://github.com/cockpit-project/node-cache.git

--- a/packaging/cockpit-files.spec.in
+++ b/packaging/cockpit-files.spec.in
@@ -5,7 +5,6 @@ Summary: A filesystem browser for Cockpit
 License: LGPL-2.1-or-later
 
 Source0: https://github.com/cockpit-project/cockpit-files/releases/download/%{version}/%{name}-%{version}.tar.xz
-Source1: https://github.com/cockpit-project/cockpit-files/releases/download/%{version}/%{name}-node-%{version}.tar.xz
 BuildArch: noarch
 ExclusiveArch: %{nodejs_arches} noarch
 BuildRequires: nodejs
@@ -24,15 +23,10 @@ Requires: cockpit-bridge >= 316
 A filesystem browser for Cockpit
 
 %prep
-%autosetup -n %{name} -a 1
-# ignore pre-built bundle in release tarball and rebuild it
-# but keep it in RHEL/CentOS-8, as that has a too old nodejs
-%if ! 0%{?rhel} || 0%{?rhel} >= 9
-rm -rf dist
-%endif
+%autosetup -n %{name}
 
 %build
-NODE_ENV=production make
+# Nothing to build
 
 %install
 %make_install PREFIX=/usr

--- a/packit.yaml
+++ b/packit.yaml
@@ -13,9 +13,6 @@ srpm_build_deps:
 actions:
   post-upstream-clone:
     - make cockpit-files.spec
-    # replace Source1 manually, as create-archive: can't handle multiple tarballs
-    - make node-cache
-    - sh -c 'sed -i "/^Source1:/ s/https:.*/$(ls *-node*.tar.xz)/" cockpit-*.spec'
   create-archive: make dist
   # files.git has no release tags; your project can drop this once you have a release
   get-current-version: make print-version


### PR DESCRIPTION
Build and maintain the node_modules/ as a submodule, using the tools/node-modules script as it's done in the cockpit repo.

Updating the node_modules/ directory after changing package.json now involves running `tools/node-modules install` and then committing the result, and pushing the submodule commit with `tools/node-modules push`.

Copy the dependabot workflow to make sure things get properly rebuilt when our `node_modules` label is set (as dependabot does for us).