### PR TITLE
Don't crash on special files

### DIFF
--- a/src/files-card-body.jsx
+++ b/src/files-card-body.jsx
@@ -402,7 +402,7 @@ export const FilesCardBody = ({
 const getFileType = (file) => {
     if (file.to === "dir") {
         return "folder";
-    } else if (file.category.class) {
+    } else if (file.category?.class) {
         return file.category.class;
     } else {
         return "file";

--- a/test/check-application
+++ b/test/check-application
@@ -192,6 +192,10 @@ class TestFiles(testlib.MachineCase):
         b.click(".breadcrumb-button:nth-of-type(2)")
         b.wait_visible("[data-item='home']")
 
+        # Enter /dev to make sure we can show special files properly
+        b.mouse("[data-item='dev']", "dblclick")
+        b.wait_visible("[data-item='urandom']")
+
         # Non-existing directory
         b.go("/files#/?path=/doesnotexists")
         b.wait_in_text(".pf-v5-c-empty-state__body", "No such file or directory")


### PR DESCRIPTION
Fixes a bug introduced in e1664765bc8de371dbb9dad64c71625e701bead0.

The file category is only present on regular files, but we access it unconditionally on anything that isn't a directory.  That causes crashes when entering /dev or anywhere else that contains devices, sockets, or FIFOs.

Make the access conditional and add a test for entering /dev.

Fixes #507