### PR TITLE
Makefile: bring back the -node.tar.xz artifact

### DIFF
--- a/packaging/cockpit-files.spec.in
+++ b/packaging/cockpit-files.spec.in
@@ -5,6 +5,7 @@ Summary: A filesystem browser for Cockpit
 License: LGPL-2.1-or-later
 
 Source0: https://github.com/cockpit-project/cockpit-files/releases/download/%{version}/%{name}-%{version}.tar.xz
+Source1: https://github.com/cockpit-project/cockpit-files/releases/download/%{version}/%{name}-node-%{version}.tar.xz
 BuildArch: noarch
 ExclusiveArch: %{nodejs_arches} noarch
 BuildRequires: nodejs
@@ -23,10 +24,16 @@ Requires: cockpit-bridge >= 316
 A filesystem browser for Cockpit
 
 %prep
-%autosetup -n %{name}
+%autosetup -n %{name} -a 1
+# ignore pre-built bundle in release tarball and rebuild it
+# but keep it in RHEL/CentOS-8, as that has a too old nodejs
+%if ! 0%{?rhel} || 0%{?rhel} >= 9
+rm -rf dist
+touch package-lock.json  # don't try to fetch node_modules again
+%endif
 
 %build
-# Nothing to build
+NODE_ENV=production make
 
 %install
 %make_install PREFIX=/usr

--- a/packit.yaml
+++ b/packit.yaml
@@ -13,6 +13,9 @@ srpm_build_deps:
 actions:
   post-upstream-clone:
     - make cockpit-files.spec
+    # replace Source1 manually, as create-archive: can't handle multiple tarballs
+    - make node-cache
+    - sh -c 'sed -i "/^Source1:/ s/https:.*/$(ls *-node*.tar.xz)/" cockpit-*.spec'
   create-archive: make dist
   # files.git has no release tags; your project can drop this once you have a release
   get-current-version: make print-version


### PR DESCRIPTION
This is a partial revert of e64ce8d7b10e1a0fd5d2625e07bd592edb8ab59c.

It's Fedora policy that we run esbuild during the rpm phase, so let's bring back the tarball with the things required to do that and include it in the packaging again.

We need to add a bit of a hack here: when we create the tarball we set all timestamps to the same value.  If `dist/` is missing, then we make sure `package-lock.json` is up to date before trying to run esbuild, but since all timestamps are the same, `make` will conclude that it needs to be rebuilt.  In turn, that calls `tools/node-modules`, which gets upset because it's not in a git checkout.  We can short-circuit that by touching `package-lock.json` when we delete `dist/`.