### PR TITLE
Resize the contextmenu area to the full height of the folder view

### DIFF
--- a/src/files-card-body.jsx
+++ b/src/files-card-body.jsx
@@ -363,7 +363,11 @@ export const FilesCardBody = ({
     });
 
     return (
-        <div id={files_parent_id} ref={folderViewRef}>
+        <div
+          id={files_parent_id}
+          className="files-contextmenu-area"
+          ref={folderViewRef}
+        >
             {contextMenu}
             {sortedFiles.length === 0 &&
                 <EmptyStatePanel

--- a/src/files-card-body.scss
+++ b/src/files-card-body.scss
@@ -1,7 +1,9 @@
 /* Stretch the view to fill the page */
 .pf-v5-c-sidebar__main,
 .pf-v5-c-sidebar__content,
-.pf-v5-c-sidebar__content > .pf-v5-c-card {
+.pf-v5-c-sidebar__content > .pf-v5-c-card,
+.files-contextmenu-area
+{
     block-size: 100%;
 }
 

--- a/test/check-application
+++ b/test/check-application
@@ -591,8 +591,16 @@ class TestFiles(testlib.MachineCase):
         self.enter_files()
         b.allow_download()
 
-        # Create folder from context menu
-        b.mouse("#files-card-parent", "contextmenu")
+        # We should be able to click anywhere in this div.
+        body_size = b.eval_js("""
+            [
+              document.getElementById('files-card-parent').offsetWidth,
+              document.getElementById('files-card-parent').offsetHeight
+            ]
+        """)
+
+        # Create folder from context menu, click in the middle to assert we can click everywhere.
+        b.mouse("#files-card-parent", "contextmenu", body_size[0] / 2, body_size[0] / 2)
         b.click(".contextMenu button:contains('Create directory')")
         b.set_input_text("#create-directory-input", "newdir")
         b.click("button.pf-m-primary")


### PR DESCRIPTION
This bug was introduced by 45aa7686f82d5b8f7ea2e which makes the content area stretch except the contextmenu div which this PR fixes and adds a test that right clicking in the middle of the div works.