### PR TITLE
package.json: use dev/depends split for node-cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ $(TARFILE): $(DIST_TEST) $(SPEC) packaging/arch/PKGBUILD packaging/debian/change
 		packaging/arch/PKGBUILD packaging/debian/changelog dist/
 
 $(NODE_CACHE): $(NODE_MODULES_TEST)
-	tar --xz $(TAR_ARGS) -cf $@ node_modules
+	tar --xz $(TAR_ARGS) -cf $@ --exclude . $$(realpath --relative-to=. $$(npm ls --all --omit dev -p))
 
 node-cache: $(NODE_CACHE)
 

--- a/package.json
+++ b/package.json
@@ -21,11 +21,6 @@
     "@typescript-eslint/eslint-plugin": "7.11.0",
     "argparse": "2.0.1",
     "chrome-remote-interface": "0.33.0",
-    "esbuild": "0.20.2",
-    "esbuild-plugin-copy": "2.1.1",
-    "esbuild-plugin-replace": "1.4.0",
-    "esbuild-sass-plugin": "3.2.0",
-    "esbuild-wasm": "0.20.2",
     "eslint": "8.57.0",
     "eslint-config-standard": "17.1.0",
     "eslint-config-standard-jsx": "11.0.0",
@@ -38,7 +33,6 @@
     "eslint-plugin-react-hooks": "4.6.2",
     "gettext-parser": "8.0.0",
     "htmlparser": "1.7.7",
-    "jed": "1.1.1",
     "language-map": "1.5.0",
     "mime-db": "1.52.0",
     "sass": "1.77.1",
@@ -48,7 +42,6 @@
     "stylelint-config-standard-scss": "13.1.0",
     "stylelint-formatter-pretty": "4.0.0",
     "stylelint-use-logical-spec": "^5.0.1",
-    "tsx": "4.11.0",
     "typescript": "5.4.5"
   },
   "dependencies": {
@@ -60,9 +53,16 @@
     "@patternfly/react-tokens": "5.3.1",
     "date-fns": "3.6.0",
     "deep-equal": "2.2.3",
-    "eslint-config-standard-react": "13.0.0",
+    "esbuild": "0.20.2",
+    "esbuild-plugin-copy": "2.1.1",
+    "esbuild-plugin-replace": "1.4.0",
+    "esbuild-sass-plugin": "3.2.0",
+    "esbuild-wasm": "0.20.2",
+    "glob": "9.3.5",
+    "jed": "1.1.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "throttle-debounce": "5.0.0"
+    "throttle-debounce": "5.0.0",
+    "tsx": "4.11.0"
   }
 }


### PR DESCRIPTION
For a package like ours, the distinction between `dependencies` and `devDependencies` is pretty theoretical, so let's firm it up a bit: our `dependencies` are now exactly the things required to run `./build.js` and our `devDependencies` are for stuff like running linters and tests.

We can use this to pare down the contents of the cockpit-files-node tarball: it shrinks to 27MB.

We explicitly add a couple of depends that we didn't properly declare before: "jed" and "glob" are both required by the `cockpit-po-plugin`. Those were only working before since they were incidentally included by other things which are now present in the `devDependencies` set (and therefore not present in the tarball).