### PR TITLE
Simplify and fix sorting options

### DIFF
--- a/src/files-card-body.jsx
+++ b/src/files-card-body.jsx
@@ -437,7 +437,7 @@ const Row = React.memo(function Item({ file, isSelected }) {
               className="item-size"
               dataLabel="size"
             >
-                {cockpit.format_bytes(file.size)}
+                {file.type === 'reg' && cockpit.format_bytes(file.size)}
             </Td>
             <Td
               className="item-date"


### PR DESCRIPTION
The result is smaller code that's easier to understand.  This also fixes sorting of directories before files when sorting by size.

Fixes #530