### PR TITLE
Simplify and fix sorting options

### DIFF
--- a/src/files-card-body.jsx
+++ b/src/files-card-body.jsx
@@ -42,42 +42,23 @@ import "./files-card-body.scss";
 const _ = cockpit.gettext;
 
 const compare = (sortBy) => {
-    const compareFileType = (a, b) => {
-        const aIsDir = (a.type === "dir" || a?.to === "dir");
-        const bIsDir = (b.type === "dir" || b?.to === "dir");
-
-        if (aIsDir && !bIsDir)
-            return -1;
-        if (!aIsDir && bIsDir)
-            return 1;
-        return 0;
+    const dir_sort = (a, b) => {
+        return Number(b.to === "dir") - Number(a.to === "dir");
     };
 
     switch (sortBy) {
     case "az":
-        return (a, b) => compareFileType(a, b) === 0
-            ? a.name.localeCompare(b.name)
-            : compareFileType(a, b);
+        return (a, b) => dir_sort(a, b) || a.name.localeCompare(b.name);
     case "za":
-        return (a, b) => compareFileType(a, b) === 0
-            ? b.name.localeCompare(a.name)
-            : compareFileType(a, b);
-    case "last_modified":
-        return (a, b) => compareFileType(a, b) === 0
-            ? (a.mtime > b.mtime
-                ? -1
-                : 1)
-            : compareFileType(a, b);
+        return (a, b) => dir_sort(a, b) || b.name.localeCompare(a.name);
     case "first_modified":
-        return (a, b) => compareFileType(a, b) === 0
-            ? (a.mtime < b.mtime
-                ? -1
-                : 1)
-            : compareFileType(a, b);
+        return (a, b) => dir_sort(a, b) || (a.mtime - b.mtime);
+    case "last_modified":
+        return (a, b) => dir_sort(a, b) || (b.mtime - a.mtime);
     case "largest_size":
-        return (a, b) => b.size - a.size;
+        return (a, b) => dir_sort(a, b) || (b.size - a.size);
     case "smallest_size":
-        return (a, b) => a.size - b.size;
+        return (a, b) => dir_sort(a, b) || (a.size - b.size);
     default:
         break;
     }

--- a/test/check-application
+++ b/test/check-application
@@ -414,6 +414,7 @@ class TestFiles(testlib.MachineCase):
         # Sort on size
         m.execute("""
             echo 'lol' > /home/admin/aaa
+            sleep 0.01   # make sure these get different timestamps on the filesystem
             truncate -s 10M /home/admin/BBB
         """)
         b.select_PF5("#sort-menu-toggle", "#sort-menu", "Largest size")
@@ -428,7 +429,9 @@ class TestFiles(testlib.MachineCase):
 
         m.execute("""
             ln -s /tmp /home/admin/ddd
+            sleep 0.01   # make sure these get different timestamps on the filesystem
             mkdir /home/admin/eee
+            sleep 0.01   # make sure these get different timestamps on the filesystem
             mkdir /home/admin/Eee
         """)
         b.wait_visible("[data-item='ddd']")
@@ -442,6 +445,36 @@ class TestFiles(testlib.MachineCase):
         b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "Eee")
         b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "aaa")
         b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "ccc")
+
+        # Sort headers also work in the list view
+        b.click("button[aria-label='Display as a list']")
+        b.wait_visible("th[aria-sort='ascending'].pf-m-selected button:contains(Name)")
+
+        # clicking reverse sort order
+        b.click("th.pf-m-selected button")
+        b.wait_visible("th[aria-sort='descending'].pf-m-selected button:contains(Name)")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "Eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "ddd")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "aaa")
+
+        b.click("th button:contains(Modified)")
+        b.wait_visible("th[aria-sort='ascending'].pf-m-selected button:contains(Modified)")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "ddd")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "Eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "BBB")
+
+        b.click("th button:contains(Size)")
+        b.wait_visible("th[aria-sort='ascending'].pf-m-selected button:contains(Size)")
+        # TODO: order of Eee eee and ddd is not guaranteed (all directories)
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "aaa")
         b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "ccc")
 
     def testDelete(self):


### PR DESCRIPTION
The result is smaller code that's easier to understand.  This also fixes sorting of directories before files when sorting by size.

Fixes #530