### PR TITLE
Drag 'n drop

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -11,8 +11,30 @@
 
 // Passthrough for layout and styling purposes, to enable main page parts to participate in the grid
 .pf-v5-c-page__main-section,
-.files-view-stack {
+.files-view-stack,
+.upload-drop-zone {
     display: contents;
+}
+
+.files-card {
+    position: relative;
+}
+
+.drag-drop-upload,
+.drag-drop-upload-blocked {
+    position: absolute;
+    z-index: 10;
+    border: 3px dashed var(--pf-v5-global--link--Color);
+    background: rgb(from var(--pf-v5-global--BackgroundColor--100) r g b / 80%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    block-size: 100%;
+    inline-size: 100%;
+
+    .pf-v5-c-empty-state__icon {
+        color: var(--pf-v5-global--Color--100);
+    }
 }
 
 .pf-v5-c-page__main {
@@ -30,12 +52,12 @@
 }
 
 .files-empty-state,
-.files-view-stack > .pf-v5-c-card,
+.files-view-stack > .upload-drop-zone > .pf-v5-c-card,
 .files-view-stack > .files-footer-info {
     grid-column: content;
 }
 
-.files-view-stack > .pf-v5-c-card {
+.files-view-stack > .upload-drop-zone > .pf-v5-c-card {
     overflow: auto;
 }
 

--- a/src/files-card-body.scss
+++ b/src/files-card-body.scss
@@ -309,3 +309,9 @@
     column-gap: var(--pf-v5-global--spacer--sm);
     text-align: start;
 }
+
+// use all available space when there is not enough files to fill the whole view
+// so drag&drop works in empty space
+.fileview-wrapper {
+    block-size: 100%;
+}

--- a/src/files-card-body.tsx
+++ b/src/files-card-body.tsx
@@ -170,7 +170,7 @@ export const FilesCardBody = ({
         return files.filter(file => file.name.startsWith(".")).length;
     }, [files]);
     const isMounted = useRef<boolean>();
-    const folderViewRef = React.useRef<HTMLDivElement>(null);
+    const folderViewRef = useRef<HTMLDivElement>(null);
 
     function calculateBoxPerRow () {
         const boxes = document.querySelectorAll(".fileview tbody > tr") as NodeListOf<HTMLElement>;
@@ -206,7 +206,7 @@ export const FilesCardBody = ({
     });
 
     useEffect(() => {
-        let folderViewElem = null;
+        let folderViewElem: HTMLDivElement | null = null;
 
         const resetSelected = (e: MouseEvent) => {
             if ((e.target instanceof HTMLElement)) {

--- a/src/files-folder-view.tsx
+++ b/src/files-folder-view.tsx
@@ -17,14 +17,34 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from "react";
+import React, { createContext, useContext, useEffect, useState, useRef } from "react";
 
 import { Card } from '@patternfly/react-core/dist/esm/components/Card';
+import { BanIcon, UploadIcon } from '@patternfly/react-icons';
 import { debounce } from "throttle-debounce";
+
+import cockpit from "cockpit";
+import { EmptyStatePanel } from "cockpit-components-empty-state";
 
 import type { FolderFileInfo } from "./app.tsx";
 import { FilesCardBody } from "./files-card-body.tsx";
 import { as_sort, FilesCardHeader } from "./header.tsx";
+
+const _ = cockpit.gettext;
+
+export interface UploadedFilesType {[name: string]:{file: File, progress: number, cancel:() => void}}
+
+interface UploadContextType {
+    uploadedFiles: UploadedFilesType,
+    setUploadedFiles: React.Dispatch<React.SetStateAction<UploadedFilesType>>,
+}
+
+export const UploadContext = createContext({
+    uploadedFiles: {},
+    setUploadedFiles: () => console.warn("UploadContext not initialized!"),
+} as UploadContextType);
+
+export const useUploadContext = () => useContext(UploadContext);
 
 export const FilesFolderView = ({
     path,
@@ -45,9 +65,13 @@ export const FilesFolderView = ({
     selected: FolderFileInfo[], setSelected: React.Dispatch<React.SetStateAction<FolderFileInfo[]>>,
     clipboard: string[], setClipboard: React.Dispatch<React.SetStateAction<string[]>>,
 }) => {
+    const dropzoneRef = useRef<HTMLDivElement>(null);
     const [currentFilter, setCurrentFilter] = useState("");
     const [isGrid, setIsGrid] = useState(localStorage.getItem("files:isGrid") !== "false");
     const [sortBy, setSortBy] = useState(as_sort(localStorage.getItem("files:sort")));
+    const [dragDropActive, setDragDropActive] = useState(false);
+    const [uploadedFiles, setUploadedFiles] = useState<{[name: string]:
+                                                        {file: File, progress: number, cancel:() => void}}>({});
     const onFilterChange = debounce(300,
                                     (_event: React.FormEvent<HTMLInputElement>, value: string) =>
                                         setCurrentFilter(value));
@@ -57,39 +81,130 @@ export const FilesFolderView = ({
         setCurrentFilter("");
     }, [path]);
 
+    // counter to manage current status of drag&drop
+    // dragging items over file entries causes a bunch of drag-enter and drag-leave
+    // events, this counter helps checking when final drag-leave event is fired
+    const dragDropCnt = useRef(0);
+
+    useEffect(() => {
+        let dropzoneElem: HTMLDivElement | null = null;
+        const isUploading = Object.keys(uploadedFiles).length !== 0;
+
+        const handleDragEnter = (event: DragEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            if (dragDropCnt.current === 0) {
+                setDragDropActive(true);
+            }
+            dragDropCnt.current++;
+        };
+
+        const handleDragLeave = (event: DragEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            dragDropCnt.current--;
+            if (dragDropCnt.current === 0) {
+                setDragDropActive(false);
+            }
+        };
+
+        const handleDrop = (event: DragEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            setDragDropActive(false);
+            dragDropCnt.current = 0;
+
+            // disable drag & drop when upload is in progress
+            if (isUploading) {
+                return;
+            }
+
+            cockpit.assert(event.dataTransfer !== null, "dataTransfer cannot be null");
+            dispatchEvent(new CustomEvent('files-drop', { detail: event.dataTransfer.files }));
+        };
+
+        const handleDragOver = (event: DragEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+        };
+
+        if (dropzoneRef.current) {
+            dropzoneElem = dropzoneRef.current;
+            dropzoneElem.addEventListener("dragenter", handleDragEnter);
+            dropzoneElem.addEventListener("dragleave", handleDragLeave);
+            dropzoneElem.addEventListener("dragover", handleDragOver, false);
+            dropzoneElem.addEventListener("drop", handleDrop, false);
+        }
+
+        return () => {
+            if (dropzoneElem) {
+                dropzoneElem.removeEventListener("dragenter", handleDragEnter);
+                dropzoneElem.removeEventListener("dragover", handleDragOver);
+                dropzoneElem.removeEventListener("dragleave", handleDragLeave);
+                dropzoneElem.removeEventListener("drop", handleDrop);
+            }
+        };
+    }, [uploadedFiles, dragDropCnt]);
+
+    const dropzoneComponent = (Object.keys(uploadedFiles).length === 0)
+        ? (
+            <div className="drag-drop-upload">
+                <EmptyStatePanel
+                  icon={UploadIcon}
+                  title={_("Drop files to upload")}
+                />
+            </div>
+        )
+        : (
+            <div className="drag-drop-upload-blocked">
+                <EmptyStatePanel
+                  icon={BanIcon}
+                  title={_("Cannot drop files, another upload is already in progress")}
+                />
+            </div>
+        );
+
     return (
-        <Card>
-            <FilesCardHeader
-              currentFilter={currentFilter}
-              onFilterChange={onFilterChange}
-              isGrid={isGrid}
-              setIsGrid={setIsGrid}
-              sortBy={sortBy}
-              setSortBy={setSortBy}
-              path={path}
-              showHidden={showHidden}
-              setShowHidden={setShowHidden}
-              selected={selected}
-              setSelected={setSelected}
-              clipboard={clipboard}
-              setClipboard={setClipboard}
-            />
-            <FilesCardBody
-              files={files}
-              currentFilter={currentFilter}
-              path={path}
-              isGrid={isGrid}
-              sortBy={sortBy}
-              setSortBy={setSortBy}
-              selected={selected}
-              setSelected={setSelected}
-              loadingFiles={loadingFiles}
-              clipboard={clipboard}
-              setClipboard={setClipboard}
-              showHidden={showHidden}
-              setShowHidden={setShowHidden}
-              setCurrentFilter={setCurrentFilter}
-            />
-        </Card>
+        <UploadContext.Provider value={{ uploadedFiles, setUploadedFiles }}>
+            <div className="upload-drop-zone" ref={dropzoneRef}>
+                <Card className="files-card">
+                    <FilesCardHeader
+                      currentFilter={currentFilter}
+                      onFilterChange={onFilterChange}
+                      isGrid={isGrid}
+                      setIsGrid={setIsGrid}
+                      sortBy={sortBy}
+                      setSortBy={setSortBy}
+                      path={path}
+                      showHidden={showHidden}
+                      setShowHidden={setShowHidden}
+                      selected={selected}
+                      setSelected={setSelected}
+                      clipboard={clipboard}
+                      setClipboard={setClipboard}
+                    />
+                    <FilesCardBody
+                      files={files}
+                      currentFilter={currentFilter}
+                      path={path}
+                      isGrid={isGrid}
+                      sortBy={sortBy}
+                      setSortBy={setSortBy}
+                      selected={selected}
+                      setSelected={setSelected}
+                      loadingFiles={loadingFiles}
+                      clipboard={clipboard}
+                      setClipboard={setClipboard}
+                      showHidden={showHidden}
+                      setShowHidden={setShowHidden}
+                      setCurrentFilter={setCurrentFilter}
+                    />
+                    {dragDropActive && dropzoneComponent}
+                </Card>
+            </div>
+        </UploadContext.Provider>
     );
 };

--- a/test/check-application
+++ b/test/check-application
@@ -979,7 +979,7 @@ class TestFiles(testlib.MachineCase):
 
         # Opening context menu from empty space deselects item
         b.click("[data-item='newdir']")
-        b.mouse("#files-card-parent tbody", "contextmenu", body_size[1] / 2, body_size[1] / 2)
+        b.mouse("#files-card-parent tbody", "contextmenu", body_size[1] / 4, body_size[1] / 4)
         b.assert_pixels(".contextMenu", "overview-context-menu")
         b.click(".contextMenu button:contains('Create directory')")
         b.set_input_text("#create-directory-input", "newdir2")
@@ -2357,6 +2357,114 @@ class TestFiles(testlib.MachineCase):
             b.wait_in_text(".pf-v5-c-alert__description", "UploadError: Not permitted to perform this action")
             b.click(".pf-v5-c-alert__action button")
             b.wait_not_present(".pf-v5-c-alert__action")
+
+            b.click("button[aria-label='Display as a list']")
+            b.go("/files#/?path=/home/admin")
+
+            # Test drag & drop upload
+            b.eval_js('''
+                      function dragFileEvent(sel, eventType, filename) {
+                          const el = window.ph_find(sel);
+
+                          let dataTransfer = null;
+                          if (filename) {
+                              // Synthetize a file DataTransfer action
+                              const content = "Random file content: 4";
+                              const file = new File([content], filename, { type: "text/plain" });
+                              dataTransfer = new DataTransfer();
+                              dataTransfer.dropEffect = "move";
+
+                              Object.defineProperty(dataTransfer, 'files', {
+                                  value: [file],
+                                  writable: false,
+                              });
+                          }
+
+                          const ev = new DragEvent(eventType, { bubbles: true, dataTransfer: dataTransfer });
+                          el.dispatchEvent(ev);
+                      }''')
+
+            def drag_file_event(selector: str, dragType: str, filename: str | None = None) -> None:
+                b.wait_visible(selector)
+                b.call_js_func('dragFileEvent', selector, dragType, filename)
+
+            b.wait_not_present(".drag-drop-upload")
+            drag_file_event(".fileview-wrapper", 'dragenter')
+            b.wait_visible(".drag-drop-upload")
+            b.assert_pixels(".files-card", "drag-drop-upload-dropzone",
+                            mock={".item-date": "Jun 19, 2024, 11:30 AM"})
+            drag_file_event(".fileview-wrapper", 'drop', 'drag-drop-testfile.txt')
+            b.wait_in_text(".pf-v5-c-alert__title", "File uploaded")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_visible("[data-item='drag-drop-testfile.txt']")
+            b.wait_not_present(".pf-v5-c-alert__action")
+            b.wait_not_present(".drag-drop-upload")
+
+            # Upload same file again - warning should show up
+            drag_file_event(".fileview-wrapper", 'dragenter')
+            b.wait_visible(".drag-drop-upload")
+            drag_file_event(".fileview-wrapper", 'dragover')
+            drag_file_event(".fileview-wrapper", 'drop', 'drag-drop-testfile.txt')
+            b.wait_in_text("h1.pf-v5-c-modal-box__title", "Replace file drag-drop-testfile.txt?")
+            b.click(".pf-v5-c-modal-box button.pf-m-link")
+            b.wait_not_present(".pf-v5-c-modal-box")
+
+            # Drag file around to test if upload icon shows up and hides accordingly
+            drag_file_event(".fileview-wrapper", 'dragenter')
+            b.wait_visible(".drag-drop-upload")
+            drag_file_event(".fileview-wrapper", 'dragleave')
+            b.wait_not_present(".drag-drop-upload")
+
+            drag_file_event(".fileview-wrapper", 'dragenter')
+            b.wait_visible(".drag-drop-upload")
+            # Hover over element which is a child of .fileview-wrapper
+            drag_file_event(".fileview-wrapper [data-item='Downloads'] .item-name", 'dragenter')
+            drag_file_event(".fileview-wrapper", 'dragleave')
+            b.wait_visible(".drag-drop-upload")
+            drag_file_event(".fileview-wrapper [data-item='project'] .item-name", 'dragenter')
+            drag_file_event(".fileview-wrapper [data-item='Downloads'] .item-name", 'dragleave')
+            b.wait_visible(".drag-drop-upload")
+            # Drag away from the .fileview-wrapper
+            drag_file_event(".fileview-wrapper [data-item='project'] .item-name", 'dragleave')
+            b.wait_not_present(".drag-drop-upload")
+            drag_file_event(".fileview-wrapper", 'dragenter')
+            b.wait_visible(".drag-drop-upload")
+            drag_file_event(".fileview-wrapper", 'dragleave')
+            b.wait_not_present(".drag-drop-upload")
+
+            # Drag & drop is disabled when upload is in progress
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", [big_file])
+            b.wait_visible("#upload-file-btn:disabled")
+            b.wait_not_present(".drag-drop-upload")
+            drag_file_event(".fileview-wrapper", 'dragenter')
+            b.wait_visible(".drag-drop-upload-blocked")
+            b.assert_pixels(".files-card", "drag-drop-upload-dropzone-blocked",
+                            mock={".item-date": "Jun 19, 2024, 11:30 AM"})
+            drag_file_event(".fileview-wrapper", 'dragleave')
+            b.wait_not_present(".drag-drop-upload-blocked")
+            # Dropping the file does nothing
+            drag_file_event(".fileview-wrapper", 'dragenter')
+            b.wait_visible(".drag-drop-upload-blocked")
+            drag_file_event(".fileview-wrapper", 'drop', 'drag-drop-file-2.txt')
+            b.wait_not_present(".drag-drop-upload")
+            b.click("#upload-progress-btn")
+            b.wait_in_text(".upload-progress-0", "bigfile.img")
+            b.wait_not_present("[data-item='drag-drop-file-2.txt']")
+            b.click("#upload-progress-btn")
+            b.click(".cancel-button-0")
+            b.click(".pf-v5-c-alert__action button")
+
+            # Change directory and upload
+            b.mouse("[data-item='project']", "dblclick")
+            drag_file_event(".fileview-wrapper", 'dragenter')
+            b.wait_visible(".drag-drop-upload")
+            drag_file_event(".fileview-wrapper", 'drop', 'drag-drop-testfile.txt')
+            b.wait_in_text(".pf-v5-c-alert__title", "File uploaded")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_visible("[data-item='drag-drop-testfile.txt']")
+            b.wait_not_present(".pf-v5-c-alert__action")
+            b.wait_not_present(".drag-drop-upload")
 
     def testFileTypes(self) -> None:
         m = self.machine


### PR DESCRIPTION
@tomasmatus interested?

One tricky thing here is we already have an upload-button component, so the eventlistener should be set up there instead so we don't have to pass `files` around.

---

# Drag-and-Drop file upload

It is now possible to upload files by simply dragging them from your desktop or a file explorer and dropping them directly into Cockpit Files.