### PR TITLE
fsinfo: change to class-based style

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -105,7 +105,7 @@ export const Application = () => {
                 { superuser: 'try' }
             );
 
-            return client.on('change', (state) => {
+            const disconnect = client.on('change', (state) => {
                 setLoading(false);
                 setLoadingFiles(!(state.info || state.error));
                 setCwdInfo(state.info || null);
@@ -118,6 +118,11 @@ export const Application = () => {
                 });
                 setFiles(files);
             });
+
+            return () => {
+                disconnect();
+                client.close();
+            };
         },
         [options, currentPath]
     );

--- a/src/event.ts
+++ b/src/event.ts
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export class EventEmitter<EM extends { [E in keyof EM]: (...args: never[]) => void }> {
+    private listeners: { [E in keyof EM]?: EM[E][] } = {};
+
+    public on<E extends keyof EM>(event: E, listener: EM[E]) {
+        const listeners = this.listeners[event] ||= [];
+        listeners.push(listener);
+        return () => {
+            listeners.splice(listeners.indexOf(listener), 1);
+        };
+    }
+
+    protected emit<E extends keyof EM>(event: E, ...args: Parameters<EM[E]>) {
+        for (const listener of this.listeners[event] || []) {
+            listener(...args);
+        }
+    }
+}

--- a/src/filetype-lookup.ts
+++ b/src/filetype-lookup.ts
@@ -9,7 +9,7 @@ export enum Category {
     VIDEO,
 }
 
-export interface CategoryMetadata {
+export interface CategoryMetadata extends Record<string, string> {
     name: string;
     class: string;
 }


### PR DESCRIPTION
Also, eject our self-rolled callback mechnism and change to the standard EventTarget API.

In order to keep type safety of the event types that we use, write a small wrapper, TypedEventTarget.  This is "mostly" safe, but we need a couple of casts: from the types on the standard EventTarget API, all event listener functions must support being called with all types of events, but ours only support being called with their specific event types.

This is starting to get ready for inclusion in the main cockpit library.