### PR TITLE
Add basic keyboard shortcuts

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -260,3 +260,63 @@
         padding-inline-start: var(--pf-v5-global--spacer--sm);
     }
 }
+
+.shortcuts-dialog {
+    h2 + .pf-v5-c-description-list {
+        margin-block-start: var(--pf-v5-global--spacer--md);
+    }
+
+    .pf-v5-l-flex {
+        // Add standard spacing between the description lists that are in a flex
+        // (PF Flex does odd stuff by default)
+        gap: var(--pf-v5-global--spacer--lg) var(--pf-v5-global--spacer--md);
+
+        > .pf-v5-c-content {
+            // Have the content prefer 20em and wrap if too narrow
+            flex: 1 1 20em;
+        }
+    }
+
+    .pf-v5-c-description-list {
+        // PF's gap is weirdly too big; let's use the PF standard size that's used everywhere else
+        --pf-v5-c-content--dl--ColumnGap: var(--pf-v5-global--spacer--md);
+        // We're setting this up as a table on the list, so they're consistent
+        display: grid;
+        // Fixing the width to the keyboard shortcuts
+        grid-template-columns: auto 1fr;
+        // Fix PF's negative margin at the end bug (as it's handled by grid layout anyway)
+        margin-block-end: 0;
+
+        .pf-v5-c-description-list__group {
+            // Ignore the grid of the group and use the grid from the description list, so everything lines up properly
+            display: contents;
+        }
+    }
+
+    kbd {
+        // Description lists bold the dt; we don't want the keys too look too bold
+        font-weight: normal;
+    }
+
+    // Style key combos
+    .keystroke {
+        display: flex;
+        align-items: center;
+        color: var(--pf-v5-global--Color--200);
+        font-size: var(--pf-v5-global--FontSize--xs);
+        gap: var(--pf-v5-global--spacer--xs);
+    }
+
+    // Style individual keys
+    .key {
+        display: inline-block;
+        background-color: var(--pf-v5-global--BackgroundColor--200);
+        border-radius: var(--pf-v5-global--BorderRadius--sm);
+        border: 1px solid var(--pf-v5-global--BorderColor--100);
+        color: var(--pf-v5-global--Color--100);
+        padding-block: var(--pf-v5-global--spacer--xs);
+        padding-inline: var(--pf-v5-global--spacer--sm);
+        box-shadow: inset 1px 1px 0 var(--pf-v5-global--BackgroundColor--100);
+        white-space: nowrap;
+    }
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -31,7 +31,7 @@ import cockpit from "cockpit";
 import { FsInfoClient, FileInfo } from "cockpit/fsinfo.ts";
 import { EmptyStatePanel } from "cockpit-components-empty-state";
 import { WithDialogs } from "dialogs";
-import { usePageLocation } from "hooks";
+import { useInit, usePageLocation } from "hooks";
 import { superuser } from "superuser";
 
 import { FilesBreadcrumbs } from "./files-breadcrumbs.tsx";
@@ -144,6 +144,21 @@ export const Application = () => {
         },
         [options, path]
     );
+
+    useInit(() => {
+        const onKeyboardNav = (e: KeyboardEvent) => {
+            if (e.key === "L" && e.ctrlKey && !e.altKey) {
+                e.preventDefault();
+                document.dispatchEvent(new Event("manual-change-dir"));
+            }
+        };
+
+        document.addEventListener("keydown", onKeyboardNav);
+
+        return () => {
+            document.removeEventListener("keydown", onKeyboardNav);
+        };
+    }, []);
 
     if (loading)
         return <EmptyStatePanel loading />;

--- a/src/dialogs/keyboardShortcutsHelp.tsx
+++ b/src/dialogs/keyboardShortcutsHelp.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import {
+    DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm
+} from "@patternfly/react-core/dist/esm/components/DescriptionList/index";
+import { Modal, ModalVariant } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
+import { Flex, } from "@patternfly/react-core/dist/esm/layouts/Flex";
+
+import cockpit from 'cockpit';
+import { DialogResult, Dialogs } from 'dialogs';
+
+const _ = cockpit.gettext;
+
+const KeyboardShortcutsHelp = ({ dialogResult } : { dialogResult: DialogResult<void> }) => {
+    const footer = (
+        <Button variant="secondary" onClick={() => dialogResult.resolve()}>{_("Close")}</Button>
+    );
+
+    const toDescriptionListGroups = (item: [React.JSX.Element, string, string]) => {
+        return (
+            <DescriptionListGroup key={item[2] + "-listgroup"}>
+                <DescriptionListTerm>
+                    {item[0]}
+                </DescriptionListTerm>
+                <DescriptionListDescription>
+                    {item[1]}
+                </DescriptionListDescription>
+            </DescriptionListGroup>
+        );
+    };
+
+    const navShortcuts: Array<[React.JSX.Element, string, string]> = [
+        [
+            <kbd className="keystroke" key="go-up">
+                <kbd className="key">Alt</kbd> + <kbd className="key">{'\u{2191}'}</kbd>
+            </kbd>,
+            _("Go up a directory"),
+            "go-up",
+        ], [
+            <kbd className="keystroke" key="go-back">
+                <kbd className="key">Alt</kbd> + <kbd className="key">{'\u{2190}'}</kbd>
+            </kbd>,
+            _("Go back"),
+            "go-back",
+        ], [
+            <kbd className="keystroke" key="go-forward">
+                <kbd className="key">Alt</kbd> + <kbd className="key">{'\u{2192}'}</kbd>
+            </kbd>,
+            _("Go forward"),
+            "go-forward",
+        ], [
+            <kbd className="keystroke" key="activate">
+                <kbd className="key">Alt</kbd> + <kbd className="key">{'\u{2193}'}</kbd>
+            </kbd>,
+            _("Activate selected item, enter directory"),
+            "activate",
+        ], [
+            <kbd className="keystroke" key="activate-enter">
+                <kbd className="key">Enter</kbd>
+            </kbd>,
+            _("Activate selected item, enter directory"),
+            "activate-enter",
+        ], [
+            <kbd className="keystroke" key="edit-path">
+                <kbd className="key">Ctrl</kbd> +
+                <kbd className="key">Shift</kbd> +
+                <kbd className="key">L</kbd>
+            </kbd>,
+            _("Edit path"),
+            "edit-path",
+        ]
+    ];
+
+    const editShortcuts: Array<[React.JSX.Element, string, string]> = [
+        [
+            <kbd className="key" key="rename">F2</kbd>,
+            _("Rename selected file or directory"),
+            "rename",
+        ], [
+            <kbd className="keystroke" key="create-dir">
+                <kbd className="key">Shift</kbd> +
+                <kbd className="key" key="mkdir">N</kbd>
+            </kbd>,
+            _("Create new directory"),
+            "mkdir",
+        ], [
+            <kbd className="keystroke" key="copy">
+                <kbd className="key">Ctrl</kbd> + <kbd className="key">C</kbd>
+            </kbd>,
+            _("Copy selected file or directory"),
+            "copy",
+        ], [
+            <kbd className="keystroke" key="paste">
+                <kbd className="key">Ctrl</kbd> + <kbd className="key">V</kbd>
+            </kbd>,
+            _("Paste file or directory"),
+            "paste",
+        ], [
+            <kbd className="keystroke" key="select-all">
+                <kbd className="key">Ctrl</kbd> + <kbd className="key">A</kbd>
+            </kbd>,
+            _("Select all"),
+            "select-all",
+        ]
+    ];
+
+    return (
+        <Modal
+          position="top"
+          title={_("Keyboard shortcuts")}
+          variant={ModalVariant.large}
+          className="shortcuts-dialog"
+          onClose={() => dialogResult.resolve()}
+          footer={footer}
+          isOpen
+        >
+            <Flex>
+                <TextContent>
+                    <Text component={TextVariants.h2}>{_("Navigation")}</Text>
+                    <DescriptionList
+                      isHorizontal
+                      isFluid
+                      isFillColumns
+                    >
+                        {navShortcuts.map(toDescriptionListGroups)}
+                    </DescriptionList>
+                </TextContent>
+                <TextContent>
+                    <Text component={TextVariants.h2}>{_("Editing")}</Text>
+                    <DescriptionList
+                      isHorizontal
+                      isFluid
+                      isFillColumns
+                    >
+                        {editShortcuts.map(toDescriptionListGroups)}
+                    </DescriptionList>
+                </TextContent>
+            </Flex>
+        </Modal>
+    );
+};
+
+export function showKeyboardShortcuts(dialogs: Dialogs) {
+    dialogs.run(KeyboardShortcutsHelp, {});
+}

--- a/src/files-breadcrumbs.tsx
+++ b/src/files-breadcrumbs.tsx
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-import React from "react";
+import React, { useCallback, useEffect } from "react";
 
 import { AlertVariant } from "@patternfly/react-core/dist/esm/components/Alert";
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/dist/esm/components/Breadcrumb";
@@ -254,6 +254,19 @@ export function FilesBreadcrumbs({ path }: { path: string }) {
     const [editMode, setEditMode] = React.useState(false);
     const [newPath, setNewPath] = React.useState<string | null>(null);
 
+    const enableEditMode = useCallback(() => {
+        setEditMode(true);
+        setNewPath(path);
+    }, [path]);
+
+    useEffect(() => {
+        document.addEventListener("manual-change-dir", enableEditMode);
+
+        return () => {
+            document.removeEventListener("manual-change-dir", enableEditMode);
+        };
+    }, [enableEditMode]);
+
     const handleInputKey = (event: React.KeyboardEvent<HTMLInputElement>) => {
         // Don't propogate navigation specific events
         if (event.key === "ArrowDown" || event.key === "ArrowUp" ||
@@ -267,11 +280,6 @@ export function FilesBreadcrumbs({ path }: { path: string }) {
         } else if (event.key === "Escape") {
             cancelPathEdit();
         }
-    };
-
-    const enableEditMode = () => {
-        setEditMode(true);
-        setNewPath(path);
     };
 
     const changePath = () => {

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -34,6 +34,7 @@ import { KebabDropdown } from "cockpit-components-dropdown";
 import { useDialogs } from "dialogs";
 
 import { FolderFileInfo, useFilesContext } from "./app.tsx";
+import { showKeyboardShortcuts } from "./dialogs/keyboardShortcutsHelp.tsx";
 import { get_menu_items } from "./menu.tsx";
 import { UploadButton } from "./upload-button.tsx";
 
@@ -154,7 +155,19 @@ export const FilesCardHeader = ({
 
     const menuItems = get_menu_items(
         path, selected, setSelected, clipboard, setClipboard, cwdInfo, addAlert, dialogs
-    ).map((option, i) => {
+    );
+
+    // This button only needs to be in the global menu
+    menuItems.push(
+        { type: "divider" },
+        {
+            id: "shortcuts-help",
+            title: _("Show keyboard shortcuts"),
+            onClick: () => showKeyboardShortcuts(dialogs)
+        }
+    );
+
+    const dropdownItems = menuItems.map((option, i) => {
         if (option.type === 'divider')
             return <Divider key={i} />;
         return (
@@ -196,7 +209,7 @@ export const FilesCardHeader = ({
                       path={path}
                     />
                     <KebabDropdown
-                      toggleButtonId="dropdown-menu" dropdownItems={menuItems}
+                      toggleButtonId="dropdown-menu" dropdownItems={dropdownItems}
                       isDisabled={cwdInfo === null} position="right"
                     />
                 </div>

--- a/test/check-application
+++ b/test/check-application
@@ -814,6 +814,9 @@ class TestFiles(testlib.MachineCase):
         b.mouse("[data-item='delete2']", "click", ctrlKey=True)
         b.wait_visible("[data-item='delete1'].row-selected")
         b.wait_visible("[data-item='delete2'].row-selected")
+        b.focus("#files-card-parent")
+        # For strange reasons ctrlKey remains pressed after the b.mouse() above (spotted in firefox)
+        b.key("Control")
         b.key("Delete")
         b.wait_in_text("h1.pf-v5-c-modal-box__title", "Delete 2 items?")
         b.assert_pixels(".pf-v5-c-modal-box", "delete-modal")
@@ -1174,6 +1177,20 @@ class TestFiles(testlib.MachineCase):
         b.wait_not_present(".pf-v5-c-modal-box")
         b.wait_visible("[data-item='renamed-foo.txt']")
 
+        # Rename file using keyboard shortcut
+        b.click("[data-item='newfile']")
+        b.key("\uE032")  # F2
+        b.wait_in_text(".pf-v5-c-modal-box__title-text", "Rename newfile")
+        b.set_input_text("#rename-item-input", "teddybear.txt")
+        b.click(".pf-v5-c-button.pf-m-primary")
+        b.wait_visible("[data-item='teddybear.txt']")
+
+        # Rename modal does not open when multiple files are selected
+        b.mouse("[data-item='dest']", "click", ctrlKey=True)
+        b.mouse("[data-item='new dir1']", "click", ctrlKey=True)
+        b.key("\uE032")  # F2
+        b.wait_not_present(".pf-v5-c-modal-box__title-text")
+
     def testHiddenItems(self) -> None:
         b = self.browser
         m = self.machine
@@ -1451,7 +1468,18 @@ class TestFiles(testlib.MachineCase):
         self.enter_files()
 
         # Check control-clicking
-        m.execute("touch /home/admin/file1 && touch /home/admin/file2")
+        m.execute("""
+        runuser -u admin touch /home/admin/file1 /home/admin/file2
+        """)
+
+        # Select all keybind
+        b.wait_visible("[data-item='file1']")
+        b.wait_visible("[data-item='file2']")
+        b.eval_js("window.focus()")
+        b.key("a", modifiers=["Control"])
+        b.wait_visible("[data-item='file1'].row-selected")
+        b.wait_visible("[data-item='file2'].row-selected")
+
         b.click("[data-item='file1']")
         b.mouse("[data-item='file2']", "click", ctrlKey=True)
         b.wait_visible("[data-item='file1'].row-selected")
@@ -1502,13 +1530,30 @@ class TestFiles(testlib.MachineCase):
 
         self.enter_files()
 
+        m.execute("""
+        runuser -u admin mkdir -p /home/admin/testdir
+        runuser -u admin mkdir -p /home/admin/anotherdir
+        """)
         create_files = ""
         for i in range(0, 4):
             create_files += f"touch /home/admin/file{i}; "
         m.execute(create_files)
 
+        # view shortcuts help dialog
+        b.click("#dropdown-menu")
+        b.click("#shortcuts-help")
+        b.wait_in_text(".shortcuts-dialog .pf-v5-c-modal-box__title-text", "Keyboard shortcuts")
+        b.assert_pixels(".shortcuts-dialog", "shortcuts-help-menu")
+        b.click(".shortcuts-dialog button.pf-m-secondary")
+        b.wait_not_present(".shortcuts-dialog")
+
         # Focus the iframe for global keybindings in Files.
         b.eval_js("window.focus()")
+
+        # Pressing ArrowRight will select first item when nothing is selected
+        b.wait_visible(".pf-v5-c-table__tbody tr:nth-child(1)")
+        b.key("ArrowRight")
+        b.wait_visible(".pf-v5-c-table__tbody tr:nth-child(1).row-selected")
 
         b.click("[data-item='file0']")
         b.wait_visible("[data-item='file0'].row-selected")
@@ -1517,6 +1562,26 @@ class TestFiles(testlib.MachineCase):
         b.wait_visible("[data-item='file1'].row-selected")
         b.key("ArrowLeft")
         b.wait_visible("[data-item='file0'].row-selected")
+
+        # Go up and down in directory hierarchy
+        b.click("[data-item='testdir']")
+        b.key("ArrowDown", modifiers=["Alt"])
+        self.assert_last_breadcrumb("testdir")
+        b.key("ArrowUp", modifiers=["Alt"])
+        b.wait_visible("[data-item='testdir']")
+
+        # Manually edit path
+        b.key("L", modifiers=["Control"])
+        b.input_text("/home/admin/anotherdir")
+        b.key("Enter")
+        self.assert_last_breadcrumb("anotherdir")
+        b.go("/files#/?path=/home/admin")
+        self.assert_last_breadcrumb("admin")
+
+        b.key("N")
+        b.set_input_text("#create-directory-input", "foodir")
+        b.click("button.pf-m-primary")
+        b.wait_visible("[data-item='foodir']")
 
         # Up / Down depends on the layout, this is tested on mobile where the
         # width is two or three columns.
@@ -1599,6 +1664,52 @@ class TestFiles(testlib.MachineCase):
         b.wait_in_text(".pf-v5-c-alert__description", "\"newfile\" exists")
         b.click("li[data-location='/home/admin'] a")
         self.assert_last_breadcrumb("admin")
+        b.click(".pf-v5-c-alert__action button")
+
+        # Copy/paste with keybinds
+        b.eval_js("window.focus()")
+        b.mouse("[data-item='newdir']", "dblclick")
+        b.click("[data-item='copyDir']")
+        b.key("c", modifiers=["Control"])
+        m.execute("runuser -u admin mkdir -p /home/admin/kbdCopy")
+        b.go("/files#/?path=/home/admin")
+        self.assert_last_breadcrumb("admin")
+        b.mouse("[data-item='kbdCopy']", "dblclick")
+        self.assert_last_breadcrumb("kbdCopy")
+        b.wait_text(".pf-v5-c-empty-state__title-text", "Directory is empty")
+        b.key("v", modifiers=["Control"])
+        b.wait_visible("[data-item='copyDir']")
+        b.go("/files#/?path=/home/admin")
+        self.assert_last_breadcrumb("admin")
+        m.execute("runuser -u admin echo 'keybindings good' > /home/admin/newdir/newfile")
+        b.mouse("[data-item='newdir']", "dblclick")
+        b.click("[data-item='loaded']")
+        b.mouse("[data-item='newfile']", "click", ctrlKey=True)
+        b.wait_visible("[data-item='loaded'].row-selected")
+        b.wait_visible("[data-item='newfile'].row-selected")
+        b.key("c", modifiers=["Control"])
+        b.go("/files#/?path=/home/admin/kbdCopy")
+        self.assert_last_breadcrumb("kbdCopy")
+        b.wait_visible("[data-item='copyDir']")
+        m.execute("runuser -u admin rmdir /home/admin/kbdCopy/copyDir")
+        b.wait_not_present("[data-item='copyDir']")
+        b.key("v", modifiers=["Control"])
+        b.wait_visible("[data-item='loaded']")
+        b.wait_visible("[data-item='newfile']")
+        self.assertEqual(m.execute("head -n 1 /home/admin/kbdCopy/newfile"), "keybindings good\n")
+
+        # File already exists error with keybinds
+        b.go("/files#/?path=/home/admin")
+        self.assert_last_breadcrumb("admin")
+        m.execute("runuser -u admin echo 'changed' > /home/admin/newdir/newfile")
+        b.click("[data-item='newfile']")
+        b.key("c", modifiers=["Control"])
+        b.go("/files#/?path=/home/admin/kbdCopy")
+        self.assert_last_breadcrumb("kbdCopy")
+        b.key("v", modifiers=["Control"])
+        b.wait_in_text("h4.pf-v5-c-alert__title", "Pasting failed")
+        b.wait_in_text(".pf-v5-c-alert__description", "\"newfile\" exists")
+        self.assertEqual(m.execute("head -n 1 /home/admin/kbdCopy/newfile"), "keybindings good\n")
 
     @testlib.skipBrowser(".upload_files() doesn't work on Firefox", "firefox")
     def testUpload(self) -> None:


### PR DESCRIPTION
fixes: #451

For now this adds following keybindings:

- `alt + arrow up`: go up one directory
- `alt + arrow down`: activate selected item, enter directory
- `Enter`: activate selected item, enter directory
- `ctrl + shift + L`: focus files breadcrumbs to manually edit it
- `F2`: rename selected file
- `shift + N`: create new directory
- `ctrl + c`: copy file/directory
- `ctrl + v`: paste file/directory
- `ctrl + a`: select all files

Alt + arrow left/right is already supported by cockpit files browser
history.

- [x] Add pixeltest for help menu
- [x] Merge #739 

---
# Files: basic keyboard shortcuts

![Screen Shot 2024-10-01 at 09 33 45](https://github.com/user-attachments/assets/d31f6a22-a576-4045-9d4e-5505d0adf030)