### PR TITLE
Go back to using Debian testing cockpit-ws package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,18 +180,11 @@ VM_DEPENDS = $(COCKPIT_WHEEL)
 VM_CUSTOMIZE_FLAGS = --install $(COCKPIT_WHEEL)
 endif
 
-# HACK: temporary bump Cockpit on Debian-testing to get > 316
-ifeq ("$(TEST_OS)","debian-testing")
-VM_CUSTOMIZE_FLAGS = --run-command "apt update && apt-get install -y -t unstable cockpit"
-else
-VM_CUSTOMIZE_FLAGS = --no-network
-endif
-
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed
 $(VM_IMAGE): export XZ_OPT=-0
 $(VM_IMAGE): $(TARFILE) $(NODE_CACHE) packaging/arch/PKGBUILD bots test/vm.install $(VM_DEPENDS)
-	bots/image-customize --fresh \
+	bots/image-customize --no-network --fresh \
 		$(VM_CUSTOMIZE_FLAGS) \
 		--upload $(NODE_CACHE):/var/tmp/ --build $(TARFILE) \
 		--script $(CURDIR)/test/vm.install $(TEST_OS)


### PR DESCRIPTION
Partially revert commit 2fe12b8f. Debian testing now has Cockpit 318, and our bots image is up to date again.