### PR TITLE
Various test fixes / maintainence

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1079,7 +1079,6 @@ class TestFiles(testlib.MachineCase):
         b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "admin")
 
     @testlib.skipBrowser(".upload_files() doesn't work on Firefox", "firefox")
-    @testlib.skipImage("Debian-testing has Cockpit 311 without new upload support in fsreplace1", "debian-testing")
     def testUpload(self) -> None:
         b = self.browser
         m = self.machine

--- a/test/check-application
+++ b/test/check-application
@@ -31,7 +31,7 @@ class TestFiles(testlib.MachineCase):
 
     def enter_files(self) -> None:
         self.login_and_go("/files")
-        self.browser.wait_not_present(".pf-c-empty-state")
+        self.browser.wait_text(".pf-v5-c-empty-state__body", "Directory is empty")
 
     def stat(self, fmt: str, path: str) -> str:
         return self.machine.execute(['stat', f'--format={fmt}', path]).strip()
@@ -176,7 +176,7 @@ class TestFiles(testlib.MachineCase):
 
         # Selected view is saved in localStorage
         b.logout()
-        self.enter_files()
+        self.login_and_go("/files")
         b.wait_visible("button[aria-label='Display as a grid']")
 
         # deleted files and directories are auto-detected
@@ -1135,7 +1135,8 @@ class TestFiles(testlib.MachineCase):
             """)
 
             b.go("/files#/?path=/mnt/upload")
-            self.browser.wait_not_present(".pf-c-empty-state")
+            b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "upload")
+            b.wait_text(".pf-v5-c-empty-state__body", "Directory is empty")
             b.click("#upload-file-btn")
             b.upload_files("#upload-file-btn + input[type='file']", [big_file])
 
@@ -1148,7 +1149,8 @@ class TestFiles(testlib.MachineCase):
             dest_dir = "/home/admin/project"
             m.execute(['runuser', '-u', 'admin', 'mkdir', dest_dir])
             b.go(f"/files#/?path={dest_dir}")
-            self.browser.wait_not_present(".pf-c-empty-state")
+            b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "project")
+            b.wait_text(".pf-v5-c-empty-state__body", "Directory is empty")
 
             files = [str(Path(tmpdir) / f"{i}.txt") for i in range(0, 5)]
             test_data = "this is a test"
@@ -1322,7 +1324,7 @@ class TestFiles(testlib.MachineCase):
 
             # Permission error
             b.go("/files#/?path=/")
-            self.browser.wait_not_present(".pf-c-empty-state")
+            b.wait_visible("[data-item='bin']")
 
             b.click("#upload-file-btn")
             b.upload_files("#upload-file-btn + input[type='file']", [files[0]])
@@ -1377,7 +1379,7 @@ class TestFiles(testlib.MachineCase):
         #   - 3 levels of additional symlinking ('file', 'sym-file', 'sym-sym-file')
         self.assertEqual(len(files), len(exts) * (6 + 2) * 3)
 
-        self.enter_files()
+        self.login_and_go("/files")
         b.click("button[aria-label='Display as a list']")
 
         # For each file we created, assert various things about how we expect

--- a/test/check-application
+++ b/test/check-application
@@ -1036,24 +1036,32 @@ class TestFiles(testlib.MachineCase):
         b.click("#dropdown-menu")
         b.click("#copy-item")
         b.mouse("[data-item='newdir']", "dblclick")
+        b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "newdir")
+        b.wait_in_text(".pf-v5-c-empty-state", "Directory is empty")
         b.click("#dropdown-menu")
         b.click("#paste-item")
         b.wait_visible("[data-item='newfile']")
         self.assertEqual(m.execute("head -n 1 /home/admin/newdir/newfile"), "test_text\n")
         b.click(".breadcrumb-button:nth-of-type(4)")
-        self.browser.wait_not_present(".pf-c-empty-state")
+        b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "admin")
+        # original file still exists
+        b.wait_visible("[data-item='newfile']")
 
         # Copy/paste directory
         m.execute("runuser -u admin mkdir /home/admin/copyDir")
+        m.execute("runuser -u admin mkdir /home/admin/newdir/loaded")
         b.click("[data-item='copyDir']")
         b.click("#dropdown-menu")
         b.click("#copy-item")
         b.mouse("[data-item='newdir']", "dblclick")
+        b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "newdir")
+        b.wait_visible("[data-item='loaded']")
         b.click("#dropdown-menu")
         b.click("#paste-item")
         b.wait_visible("[data-item='copyDir']")
         b.click(".breadcrumb-button:nth-of-type(4)")
-        self.browser.wait_not_present(".pf-c-empty-state")
+        b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "admin")
+        b.wait_visible("[data-item='copyDir']")
 
         # File already exists error
         m.execute("runuser -u admin echo 'changed' > /home/admin/newfile")
@@ -1068,7 +1076,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_in_text("h4.pf-v5-c-alert__title", "Pasting failed")
         b.wait_in_text(".pf-v5-c-alert__description", "\"newfile\" exists")
         b.click(".breadcrumb-button:nth-of-type(4)")
-        self.browser.wait_not_present(".pf-c-empty-state")
+        b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "admin")
 
     @testlib.skipBrowser(".upload_files() doesn't work on Firefox", "firefox")
     @testlib.skipImage("Debian-testing has Cockpit 311 without new upload support in fsreplace1", "debian-testing")


### PR DESCRIPTION
The test was flaky as changing the directory didn't wait for the state to fully sync so a paste would paste in the previous directory.

Additionally add a check that after pasting going back to the original folder still shows the copied file.


Enable the upload test for debian-testing as we have Cockpit > 311 now.
