### PR TITLE
test/reference: update to unbreak main

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -290,7 +290,8 @@ class TestFiles(testlib.MachineCase):
         b.wait_visible("[data-item='admin']")
 
         # Changing hostname updates breadcrumb
-        self.restore_file("/etc/hostname")
+        original_hostname = m.execute('hostnamectl hostname').strip()
+        self.addCleanup(m.execute, ['hostnamectl', 'set-hostname', original_hostname])
         m.execute("hostnamectl set-hostname files")
         b.wait_text(".breadcrumb-button:nth-of-type(2)", "files")
 


### PR DESCRIPTION
We landed the PR to introduce pixel tests — #570 — in parallel with a PR that changed the visual style of the app — #574.

Update the pixel tests to adjust for the changes from #574.

Fixes #575