### PR TITLE
lots of code restructuring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 0d25127f6cc6c8eb3d39311d68f2dcf84d1ce6a8 # 318 + 39 commits
+COCKPIT_REPO_COMMIT = d3b06712ff672927161cd7f051fd84af421dab9d # 318 + 58 commits
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/src/dialogs/delete.tsx
+++ b/src/dialogs/delete.tsx
@@ -1,0 +1,100 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from 'react';
+
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Modal, ModalVariant } from '@patternfly/react-core/dist/esm/components/Modal';
+
+import cockpit from 'cockpit';
+import { InlineNotification } from 'cockpit-components-inline-notification';
+import { useDialogs } from 'dialogs';
+
+import type { FolderFileInfo } from '../app';
+
+const _ = cockpit.gettext;
+
+export const ConfirmDeletionDialog = ({ path, selected, setSelected } : {
+    path: string,
+    selected: FolderFileInfo[], setSelected: React.Dispatch<React.SetStateAction<FolderFileInfo[]>>,
+}) => {
+    const Dialogs = useDialogs();
+    const [errorMessage, setErrorMessage] = useState(null);
+    const [forceDelete, setForceDelete] = useState(false);
+
+    let modalTitle;
+    if (selected.length > 1) {
+        modalTitle = cockpit.format(forceDelete ? _("Force delete $0 items") : _("Delete $0 items?"), selected.length);
+    } else {
+        const selectedItem = selected[0];
+        if (selectedItem.type === "reg") {
+            modalTitle = cockpit.format(
+                forceDelete ? _("Force delete file $0?") : _("Delete file $0?"), selectedItem.name
+            );
+        } else if (selectedItem.type === "lnk") {
+            modalTitle = cockpit.format(
+                forceDelete ? _("Force delete link $0?") : _("Delete link $0?"), selectedItem.name
+            );
+        } else if (selectedItem.type === "dir") {
+            modalTitle = cockpit.format(
+                forceDelete ? _("Force delete directory $0?") : _("Delete directory $0?"), selectedItem.name
+            );
+        } else {
+            modalTitle = cockpit.format(forceDelete ? _("Force delete $0") : _("Delete $0?"), selectedItem.name);
+        }
+    }
+
+    const deleteItem = () => {
+        const args = ["rm", "-r"];
+        // TODO: Make force more sensible https://github.com/cockpit-project/cockpit-files/issues/363
+        cockpit.spawn([...args, ...selected.map(f => path + f.name)], { err: "message", superuser: "try" })
+                .then(() => {
+                    setSelected([]);
+                    Dialogs.close();
+                })
+                .catch(err => {
+                    setErrorMessage(err.message);
+                    setForceDelete(true);
+                });
+    };
+
+    return (
+        <Modal
+          position="top"
+          title={modalTitle}
+          titleIconVariant="warning"
+          variant={ModalVariant.medium}
+          isOpen
+          onClose={Dialogs.close}
+          footer={
+              <>
+                  <Button variant="danger" onClick={deleteItem}>{_("Delete")}</Button>
+                  <Button variant="link" onClick={Dialogs.close}>{_("Cancel")}</Button>
+              </>
+          }
+        >
+            {errorMessage &&
+            <InlineNotification
+              type="danger"
+              text={errorMessage}
+              isInline
+            />}
+        </Modal>
+    );
+};

--- a/src/dialogs/permissions.jsx
+++ b/src/dialogs/permissions.jsx
@@ -27,7 +27,6 @@ import { Stack } from '@patternfly/react-core/dist/esm/layouts/Stack';
 
 import cockpit from 'cockpit';
 import { InlineNotification } from 'cockpit-components-inline-notification';
-import { useDialogs } from 'dialogs';
 import { useInit } from 'hooks';
 import { etc_group_syntax, etc_passwd_syntax } from 'pam_user_parser';
 import { superuser } from 'superuser';
@@ -37,8 +36,7 @@ import { map_permissions, inode_types } from '../common';
 
 const _ = cockpit.gettext;
 
-const EditPermissionsModal = ({ selected, path }) => {
-    const Dialogs = useDialogs();
+const EditPermissionsModal = ({ dialogResult, selected, path }) => {
     const { cwdInfo } = useFilesContext();
 
     // Nothing selected means we act on the current working directory
@@ -93,7 +91,7 @@ const EditPermissionsModal = ({ selected, path }) => {
                 await cockpit.spawn(["chown", owner + ":" + group, directory],
                                     { superuser: "try", err: "message" });
 
-            Dialogs.close();
+            dialogResult.resolve();
         } catch (err) {
             setErrorMessage(err.message);
         }
@@ -123,7 +121,7 @@ const EditPermissionsModal = ({ selected, path }) => {
           title={cockpit.format(_("“$0” permissions"), selected.name)}
           description={inode_types[selected.type] || "Unknown type"}
           isOpen
-          onClose={Dialogs.close}
+          onClose={dialogResult.resolve}
           footer={
               <>
                   <Button
@@ -132,7 +130,7 @@ const EditPermissionsModal = ({ selected, path }) => {
                   >
                       {_("Change")}
                   </Button>
-                  <Button variant="link" onClick={Dialogs.close}>{_("Cancel")}</Button>
+                  <Button variant="link" onClick={dialogResult.resolve}>{_("Cancel")}</Button>
               </>
           }
         >
@@ -221,6 +219,6 @@ const EditPermissionsModal = ({ selected, path }) => {
     );
 };
 
-export function editPermissions(dialogs, selected, path) {
+export function edit_permissions(dialogs, selected, path) {
     dialogs.run(EditPermissionsModal, { selected, path });
 }

--- a/src/dialogs/rename.tsx
+++ b/src/dialogs/rename.tsx
@@ -1,0 +1,126 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from 'react';
+
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Form, FormGroup } from '@patternfly/react-core/dist/esm/components/Form';
+import { Modal, ModalVariant } from '@patternfly/react-core/dist/esm/components/Modal';
+import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput';
+import { Stack } from '@patternfly/react-core/dist/esm/layouts/Stack';
+
+import cockpit from 'cockpit';
+import { FormHelper } from 'cockpit-components-form-helper';
+import { InlineNotification } from 'cockpit-components-inline-notification';
+import { useDialogs } from 'dialogs';
+
+import { FolderFileInfo, useFilesContext } from '../app';
+
+const _ = cockpit.gettext;
+
+function check_name(candidate: string, entries: Record<string, unknown>) {
+    if (candidate === "") {
+        return _("Name cannot be empty.");
+    } else if (candidate.length >= 256) {
+        return _("Name too long.");
+    } else if (candidate.includes("/")) {
+        return _("Name cannot include a /.");
+    } else if (candidate in entries) {
+        return _("File or directory already exists");
+    } else {
+        return null;
+    }
+}
+
+export const RenameItemModal = ({ path, selected } : {
+    path: string[],
+    selected: FolderFileInfo
+}) => {
+    const Dialogs = useDialogs();
+    const { cwdInfo } = useFilesContext();
+    const [name, setName] = useState(selected.name);
+    const [nameError, setNameError] = useState<string | null>(null);
+    const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
+
+    let title;
+    if (selected.type === "reg") {
+        title = cockpit.format(_("Rename file $0"), selected.name);
+    } else if (selected.type === "lnk") {
+        title = cockpit.format(_("Rename link $0"), selected.name);
+    } else if (selected.type === "dir") {
+        title = cockpit.format(_("Rename directory $0"), selected.name);
+    } else {
+        title = _("Rename $0", selected.name);
+    }
+
+    const renameItem = () => {
+        const newPath = path.join("/") + "/" + name;
+
+        cockpit.spawn(["mv", "--no-target-directory", path.join("/") + "/" + selected.name, newPath],
+                      { superuser: "try", err: "message" })
+                .then(() => {
+                    Dialogs.close();
+                }, err => setErrorMessage(err.message));
+    };
+
+    return (
+        <Modal
+          position="top"
+          title={title}
+          variant={ModalVariant.small}
+          isOpen
+          onClose={Dialogs.close}
+          footer={
+              <>
+                  <Button
+                    variant="primary"
+                    onClick={renameItem}
+                    isDisabled={errorMessage !== undefined || nameError !== null}
+                  >
+                      {_("Rename")}
+                  </Button>
+                  <Button variant="link" onClick={Dialogs.close}>{_("Cancel")}</Button>
+              </>
+          }
+        >
+            <Stack>
+                {errorMessage !== undefined &&
+                <InlineNotification
+                  type="danger"
+                  text={errorMessage}
+                  isInline
+                />}
+                <Form isHorizontal>
+                    <FormGroup fieldId="rename-item-input" label={_("New name")}>
+                        <TextInput
+                          value={name}
+                          onChange={(_, val) => {
+                              setNameError(check_name(val, cwdInfo?.entries || {}));
+                              setErrorMessage(undefined);
+                              setName(val);
+                          }}
+                          id="rename-item-input"
+                        />
+                        <FormHelper fieldId="rename-item-input" helperTextInvalid={nameError} />
+                    </FormGroup>
+                </Form>
+            </Stack>
+        </Modal>
+    );
+};

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+
+import type { FolderFileInfo } from './app';
+
+export function downloadFile(currentPath: string, selected: FolderFileInfo) {
+    const query = window.btoa(JSON.stringify({
+        payload: "fsread1",
+        binary: "raw",
+        path: `${currentPath}/${selected.name}`,
+        superuser: "try",
+        external: {
+            "content-disposition": `attachment; filename="${selected.name}"`,
+            "content-type": "application/octet-stream",
+        }
+    }));
+
+    const prefix = (new URL(cockpit.transport.uri("channel/" + cockpit.transport.csrf_token))).pathname;
+    window.open(`${prefix}?${query}`);
+}

--- a/src/files-card-body.tsx
+++ b/src/files-card-body.tsx
@@ -32,7 +32,7 @@ import { useDialogs } from "dialogs";
 import * as timeformat from "timeformat";
 
 import { FolderFileInfo, useFilesContext } from "./app";
-import { ConfirmDeletionDialog } from "./dialogs/delete";
+import { confirm_delete } from "./dialogs/delete";
 import { Sort, filterColumnMapping, filterColumns } from "./header";
 import { get_menu_items } from "./menu";
 
@@ -264,13 +264,7 @@ export const FilesCardBody = ({
             } else if (e.key === "Enter" && selected.length === 1) {
                 onDoubleClickNavigate(selected[0]);
             } else if (e.key === "Delete" && selected.length !== 0) {
-                const currentPath = path.join("/") + "/";
-                Dialogs.show(
-                    <ConfirmDeletionDialog
-                      selected={selected} path={currentPath}
-                      setSelected={setSelected}
-                    />
-                );
+                confirm_delete(Dialogs, path.join("/") + "/", selected, setSelected);
             }
         };
 

--- a/src/files-card-body.tsx
+++ b/src/files-card-body.tsx
@@ -32,7 +32,7 @@ import { useDialogs } from "dialogs";
 import * as timeformat from "timeformat";
 
 import { FolderFileInfo, useFilesContext } from "./app";
-import { ConfirmDeletionDialog } from "./fileActions";
+import { ConfirmDeletionDialog } from "./dialogs/delete";
 import { Sort, filterColumnMapping, filterColumns } from "./header";
 import { get_menu_items } from "./menu";
 

--- a/src/files-card-body.tsx
+++ b/src/files-card-body.tsx
@@ -69,10 +69,10 @@ const ContextMenuItems = ({ path, selected, setSelected, clipboard, setClipboard
     selected: FolderFileInfo[], setSelected: React.Dispatch<React.SetStateAction<FolderFileInfo[]>>,
     clipboard: string[], setClipboard: React.Dispatch<React.SetStateAction<string[]>>,
 }) => {
-    const Dialogs = useDialogs();
+    const dialogs = useDialogs();
     const { addAlert, cwdInfo } = useFilesContext();
     const menuItems = get_menu_items(
-        path, selected, setSelected, clipboard, setClipboard, cwdInfo, addAlert, Dialogs
+        path, selected, setSelected, clipboard, setClipboard, cwdInfo, addAlert, dialogs
     );
 
     return (
@@ -119,7 +119,7 @@ export const FilesCardBody = ({
     showHidden: boolean,
 }) => {
     const [boxPerRow, setBoxPerRow] = useState(0);
-    const Dialogs = useDialogs();
+    const dialogs = useDialogs();
 
     const sortedFiles = useMemo(() => {
         return files
@@ -264,7 +264,7 @@ export const FilesCardBody = ({
             } else if (e.key === "Enter" && selected.length === 1) {
                 onDoubleClickNavigate(selected[0]);
             } else if (e.key === "Delete" && selected.length !== 0) {
-                confirm_delete(Dialogs, path.join("/") + "/", selected, setSelected);
+                confirm_delete(dialogs, path.join("/") + "/", selected, setSelected);
             }
         };
 
@@ -275,11 +275,11 @@ export const FilesCardBody = ({
             folderViewElem.addEventListener("contextmenu", handleContextMenu);
         }
 
-        if (!isMounted.current && !Dialogs.isActive()) {
+        if (!isMounted.current && !dialogs.isActive()) {
             isMounted.current = true;
             document.addEventListener("keydown", onKeyboardNav);
         }
-        if (Dialogs.isActive())
+        if (dialogs.isActive())
             document.removeEventListener("keydown", onKeyboardNav);
         return () => {
             isMounted.current = false;
@@ -296,7 +296,7 @@ export const FilesCardBody = ({
         boxPerRow,
         selected,
         onDoubleClickNavigate,
-        Dialogs,
+        dialogs,
         path,
     ]);
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,0 @@
-interface Window {
-    debugging?: string;
-}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,7 +35,13 @@ import { Application } from "./app";
  */
 import "./app.scss";
 
-document.addEventListener("DOMContentLoaded", function () {
-    const root = createRoot(document.getElementById("app"));
+declare global {
+    interface Window {
+        debugging?: string;
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    const root = createRoot(document.getElementById("app")!);
     root.render(<Application />);
 });

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -27,10 +27,10 @@ import type { FileInfo } from "fsinfo";
 
 import type { FolderFileInfo } from "./app";
 import { basename } from "./common";
-import { ConfirmDeletionDialog } from './dialogs/delete';
-import { CreateDirectoryModal } from './dialogs/mkdir';
-import { editPermissions } from './dialogs/permissions';
-import { RenameItemModal } from './dialogs/rename';
+import { confirm_delete } from './dialogs/delete';
+import { show_create_directory_dialog } from './dialogs/mkdir';
+import { edit_permissions } from './dialogs/permissions';
+import { show_rename_dialog } from './dialogs/rename';
 import { downloadFile } from './download';
 
 const _ = cockpit.gettext;
@@ -81,13 +81,13 @@ export function get_menu_items(
             {
                 id: "create-item",
                 title: _("Create directory"),
-                onClick: () => dialogs.show(<CreateDirectoryModal currentPath={currentPath} />),
+                onClick: () => show_create_directory_dialog(dialogs, currentPath)
             },
             { type: "divider" },
             {
                 id: "edit-permissions",
                 title: _("Edit permissions"),
-                onClick: () => editPermissions(dialogs, null, path)
+                onClick: () => edit_permissions(dialogs, null, path)
             }
         );
     } else if (selected.length === 1) {
@@ -101,28 +101,19 @@ export function get_menu_items(
             {
                 id: "edit-permissions",
                 title: _("Edit permissions"),
-                onClick: () => editPermissions(dialogs, selected[0], path)
+                onClick: () => edit_permissions(dialogs, selected[0], path)
             },
             {
                 id: "rename-item",
                 title: _("Rename"),
-                onClick: () => {
-                    dialogs.show(<RenameItemModal path={path} selected={selected[0]} />);
-                },
+                onClick: () => show_rename_dialog(dialogs, path, selected[0])
             },
             { type: "divider" },
             {
                 id: "delete-item",
                 title: _("Delete"),
                 className: "pf-m-danger",
-                onClick: () => {
-                    dialogs.show(
-                        <ConfirmDeletionDialog
-                          selected={selected} path={currentPath}
-                          setSelected={setSelected}
-                        />
-                    );
-                }
+                onClick: () => confirm_delete(dialogs, currentPath, selected, setSelected)
             },
         );
         if (selected[0].type === "reg")
@@ -145,14 +136,7 @@ export function get_menu_items(
                 id: "delete-item",
                 title: _("Delete"),
                 className: "pf-m-danger",
-                onClick: () => {
-                    dialogs.show(
-                        <ConfirmDeletionDialog
-                          selected={selected} path={currentPath}
-                          setSelected={setSelected}
-                        />
-                    );
-                },
+                onClick: () => confirm_delete(dialogs, currentPath, selected, setSelected)
             }
         );
     }

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -22,6 +22,7 @@ import React from "react";
 import { AlertVariant } from "@patternfly/react-core/dist/esm/components/Alert";
 
 import cockpit from "cockpit";
+import type { Dialogs } from 'dialogs';
 import type { FileInfo } from "fsinfo";
 
 import type { FolderFileInfo } from "./app";
@@ -51,7 +52,7 @@ export function get_menu_items(
     clipboard: string[], setClipboard: React.Dispatch<React.SetStateAction<string[]>>,
     cwdInfo: FileInfo | null,
     addAlert: (title: string, variant: AlertVariant, key: string, detail?: string) => void,
-    Dialogs: { show(element: React.JSX.Element): void }
+    dialogs: Dialogs,
 ) {
     const currentPath = path.join("/") + "/";
     const menuItems: MenuItem[] = [];
@@ -82,13 +83,13 @@ export function get_menu_items(
             {
                 id: "create-item",
                 title: _("Create directory"),
-                onClick: () => Dialogs.show(<CreateDirectoryModal currentPath={currentPath} />),
+                onClick: () => dialogs.show(<CreateDirectoryModal currentPath={currentPath} />),
             },
             { type: "divider" },
             {
                 id: "edit-permissions",
                 title: _("Edit permissions"),
-                onClick: () => editPermissions(Dialogs, null, path)
+                onClick: () => editPermissions(dialogs, null, path)
             }
         );
     } else if (selected.length === 1) {
@@ -102,18 +103,13 @@ export function get_menu_items(
             {
                 id: "edit-permissions",
                 title: _("Edit permissions"),
-                onClick: () => editPermissions(Dialogs, selected[0], path)
+                onClick: () => editPermissions(dialogs, selected[0], path)
             },
             {
                 id: "rename-item",
                 title: _("Rename"),
                 onClick: () => {
-                    Dialogs.show(
-                        <RenameItemModal
-                          path={path}
-                          selected={selected[0]}
-                        />
-                    );
+                    dialogs.show(<RenameItemModal path={path} selected={selected[0]} />);
                 },
             },
             { type: "divider" },
@@ -122,7 +118,7 @@ export function get_menu_items(
                 title: _("Delete"),
                 className: "pf-m-danger",
                 onClick: () => {
-                    Dialogs.show(
+                    dialogs.show(
                         <ConfirmDeletionDialog
                           selected={selected} path={currentPath}
                           setSelected={setSelected}
@@ -152,7 +148,7 @@ export function get_menu_items(
                 title: _("Delete"),
                 className: "pf-m-danger",
                 onClick: () => {
-                    Dialogs.show(
+                    dialogs.show(
                         <ConfirmDeletionDialog
                           selected={selected} path={currentPath}
                           setSelected={setSelected}

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -27,13 +27,11 @@ import type { FileInfo } from "fsinfo";
 
 import type { FolderFileInfo } from "./app";
 import { basename } from "./common";
-import { CreateDirectoryModal } from "./dialogs/mkdir";
-import {
-    ConfirmDeletionDialog,
-    RenameItemModal,
-    editPermissions,
-    downloadFile
-} from "./fileActions";
+import { ConfirmDeletionDialog } from './dialogs/delete';
+import { CreateDirectoryModal } from './dialogs/mkdir';
+import { editPermissions } from './dialogs/permissions';
+import { RenameItemModal } from './dialogs/rename';
+import { downloadFile } from './download';
 
 const _ = cockpit.gettext;
 

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -38,7 +38,7 @@ import * as timeformat from "timeformat";
 
 import { useFilesContext } from "./app";
 import { get_permissions } from "./common";
-import { editPermissions } from "./dialogs/permissions";
+import { edit_permissions } from "./dialogs/permissions";
 import { get_menu_items } from "./menu";
 
 const _ = cockpit.gettext;
@@ -175,7 +175,7 @@ export const SidebarPanelDetails = ({
                 <Button
                   variant="secondary"
                   onClick={() => {
-                      editPermissions(Dialogs, selected[0], path);
+                      edit_permissions(Dialogs, selected[0], path);
                   }}
                 >
                     {_("Edit permissions")}

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -107,7 +107,7 @@ export const SidebarPanelDetails = ({
         if (selected.length === 1) {
             const filePath = path.join("/") + "/" + selected[0]?.name;
 
-            cockpit.spawn(["file", "--brief", filePath], { superuser: "try", error: "message" })
+            cockpit.spawn(["file", "--brief", filePath], { superuser: "try", err: "message" })
                     .then(res => setInfo(res?.trim()))
                     .catch(error => console.warn(`Failed to run file --brief on ${filePath}: ${error.toString()}`));
         }

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -109,7 +109,7 @@ export const SidebarPanelDetails = ({
         }
     }, [path, selected]);
 
-    const Dialogs = useDialogs();
+    const dialogs = useDialogs();
     const directory_name = path[path.length - 1];
     const hidden_count = files.filter(file => file.name.startsWith(".")).length;
     let shown_items = cockpit.format(cockpit.ngettext("$0 item", "$0 items", files.length), files.length);
@@ -117,7 +117,7 @@ export const SidebarPanelDetails = ({
         shown_items += " " + cockpit.format(cockpit.ngettext("($0 hidden)", "($0 hidden)", hidden_count), hidden_count);
 
     const menuItems = get_menu_items(
-        path, selected, setSelected, clipboard, setClipboard, cwdInfo, addAlert, Dialogs
+        path, selected, setSelected, clipboard, setClipboard, cwdInfo, addAlert, dialogs
     ).map((option, i) => {
         if (option.type === 'divider')
             return <Divider key={i} />;
@@ -175,7 +175,7 @@ export const SidebarPanelDetails = ({
                 <Button
                   variant="secondary"
                   onClick={() => {
-                      edit_permissions(Dialogs, selected[0], path);
+                      edit_permissions(dialogs, selected[0], path);
                   }}
                 >
                     {_("Edit permissions")}

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -48,42 +48,46 @@ const getDescriptionListItems = selected => {
         {
             id: "description-list-last-modified",
             label: _("Last modified"),
-            value: timeformat.dateTime(selected.mtime * 1000)
+            value: 'mtime' in selected ? timeformat.dateTime(selected.mtime * 1000) : _('unknown')
         },
         {
             id: "description-list-owner",
             label: _("Owner"),
-            value: selected.user
+            value: 'user' in selected ? selected.user : _('unknown')
         },
         {
             id: "description-list-group",
             label: _("Group"),
-            value: selected.group
+            value: 'group' in selected ? selected.group : _('unknown')
         },
         ...(selected.type === "reg"
             ? [
                 {
                     id: "description-list-size",
                     label: _("Size"),
-                    value: cockpit.format_bytes(selected.size),
+                    value: cockpit.format_bytes(selected.size) || _('unknown'),
                 },
             ]
             : []),
-        {
-            id: "description-list-owner-permissions",
-            label: _("Owner permissions"),
-            value: get_permissions(selected.mode >> 6),
-        },
-        {
-            id: "description-list-group-permissions",
-            label: _("Group permissions"),
-            value: get_permissions(selected.mode >> 3),
-        },
-        {
-            id: "description-list-other-permissions",
-            label: _("Other permissions"),
-            value: get_permissions(selected.mode >> 0),
-        },
+        ...('mode' in selected
+            ? [
+                {
+                    id: "description-list-owner-permissions",
+                    label: _("Owner permissions"),
+                    value: get_permissions(selected.mode >> 6),
+                },
+                {
+                    id: "description-list-group-permissions",
+                    label: _("Group permissions"),
+                    value: get_permissions(selected.mode >> 3),
+                },
+                {
+                    id: "description-list-other-permissions",
+                    label: _("Other permissions"),
+                    value: get_permissions(selected.mode >> 0),
+                },
+            ]
+            : [])
     ]);
 };
 

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -38,7 +38,7 @@ import * as timeformat from "timeformat";
 
 import { useFilesContext } from "./app";
 import { get_permissions } from "./common";
-import { editPermissions } from "./fileActions";
+import { editPermissions } from "./dialogs/permissions";
 import { get_menu_items } from "./menu";
 
 const _ = cockpit.gettext;

--- a/src/sidebar.tsx
+++ b/src/sidebar.tsx
@@ -36,14 +36,14 @@ import { KebabDropdown } from "cockpit-components-dropdown";
 import { useDialogs } from "dialogs";
 import * as timeformat from "timeformat";
 
-import { useFilesContext } from "./app";
+import { FolderFileInfo, useFilesContext } from "./app";
 import { get_permissions } from "./common";
 import { edit_permissions } from "./dialogs/permissions";
 import { get_menu_items } from "./menu";
 
 const _ = cockpit.gettext;
 
-const getDescriptionListItems = selected => {
+function getDescriptionListItems(selected: FolderFileInfo) {
     return ([
         {
             id: "description-list-last-modified",
@@ -89,18 +89,16 @@ const getDescriptionListItems = selected => {
             ]
             : [])
     ]);
-};
+}
 
-export const SidebarPanelDetails = ({
-    files,
-    path,
-    selected,
-    showHidden,
-    setSelected,
-    clipboard,
-    setClipboard,
+export const SidebarPanelDetails = ({ files, path, selected, setSelected, showHidden, clipboard, setClipboard } : {
+    files: FolderFileInfo[],
+    path: string[],
+    selected: FolderFileInfo[], setSelected: React.Dispatch<React.SetStateAction<FolderFileInfo[]>>,
+    showHidden: boolean,
+    clipboard: string[], setClipboard: React.Dispatch<React.SetStateAction<string[]>>
 }) => {
-    const [info, setInfo] = useState(null);
+    const [info, setInfo] = useState<string | null>(null);
     const { addAlert, cwdInfo } = useFilesContext();
 
     useEffect(() => {
@@ -168,7 +166,7 @@ export const SidebarPanelDetails = ({
             {selected.length === 1 &&
             <CardBody>
                 <DescriptionList id="description-list-sidebar" className="sidebar-details">
-                    {getDescriptionListItems(selected[0]).map((item, index) => (
+                    {getDescriptionListItems(selected[0]).map(item => (
                         <DescriptionListGroup key={item.id} id={item.id}>
                             <DescriptionListTerm>{item.label}</DescriptionListTerm>
                             <DescriptionListDescription>

--- a/src/upload-button.tsx
+++ b/src/upload-button.tsx
@@ -133,7 +133,7 @@ export const UploadButton = ({
 }) => {
     const ref = useRef<HTMLInputElement>(null);
     const { addAlert, cwdInfo } = useFilesContext();
-    const Dialogs = useDialogs();
+    const dialogs = useDialogs();
     const [showPopover, setPopover] = React.useState(false);
     const [uploadedFiles, setUploadedFiles] = useState<{[name: string]:
                                                         {file: File, progress: number, cancel:() => void}}>({});
@@ -177,7 +177,7 @@ export const UploadButton = ({
                 continue;
             } else if (file) {
                 try {
-                    resolution = await Dialogs.run(FileConflictDialog, {
+                    resolution = await dialogs.run(FileConflictDialog, {
                         path, file, uploadFile, isMultiUpload: event.target.files.length > 1
                     });
                 } catch (exc) {

--- a/test/check-application
+++ b/test/check-application
@@ -946,12 +946,27 @@ class TestFiles(testlib.MachineCase):
 
         self.enter_files()
 
+        # Make a directory that's not readable to the admin user
         m.execute("mkdir /home/admin/testdir && chmod 400 /home/admin/testdir")
         b.mouse("[data-item='testdir']", "dblclick")
         b.wait_not_present(".pf-v5-c-empty-state")
         b.drop_superuser()
         b.wait_in_text(".pf-v5-c-empty-state", "Permission denied")
         b.assert_pixels(".pf-v5-c-page__main", "error-folder-view")
+
+        # clicking on the home button should take us to the home directory
+        b.click(".breadcrumb-button:nth-of-type(4)")
+
+        # Now set a+r.  We will be able to enter the directory now, and see the
+        # files present, but not read any information about them (not +x).
+        m.execute('touch /home/admin/testdir/testfile && chmod a+r /home/admin/testdir')
+        b.mouse("[data-item='testdir']", "dblclick")
+        b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "testdir")
+        b.click("[data-item='testfile']")
+        b.wait_in_text("#sidebar-card-header", "testfile")
+        b.wait_text("#description-list-owner dd", "unknown")
+        b.wait_text("#description-list-group dd", "unknown")
+        b.wait_text("#description-list-last-modified dd", "unknown")
 
     def testMultiSelect(self) -> None:
         b = self.browser


### PR DESCRIPTION
 - finish up the job of killing off `src/fileActions.jsx`, splitting it into many separate files
 - clean up the interface used to show dialogs — each dialog now has a function to call instead of the caller having to construct and Dialogs.show() the widget themselves
 - adapt to the new `Dialogs.run()` interface, dropping all uses of `Dialogs.show()` and `Dialogs.close()`
 - the usual obligatory typescript porting

Of course, this first:

 - [x] https://github.com/cockpit-project/cockpit/pull/20636