### PR TITLE
Wrap EmptyStatePanel in a Card for consistency

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -22,6 +22,7 @@ import React, { useContext, useEffect, useMemo, useState } from "react";
 import {
     AlertGroup, Alert, AlertVariant, AlertActionCloseButton
 } from "@patternfly/react-core/dist/esm/components/Alert";
+import { Card } from "@patternfly/react-core/dist/esm/components/Card";
 import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page";
 import { Sidebar, SidebarPanel, SidebarContent } from "@patternfly/react-core/dist/esm/components/Sidebar";
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
@@ -166,10 +167,12 @@ export const Application = () => {
                         <Sidebar isPanelRight hasGutter>
                             <SidebarContent>
                                 {errorMessage &&
-                                <EmptyStatePanel
-                                  paragraph={errorMessage}
-                                  icon={ExclamationCircleIcon}
-                                />}
+                                <Card>
+                                    <EmptyStatePanel
+                                      paragraph={errorMessage}
+                                      icon={ExclamationCircleIcon}
+                                    />
+                                </Card>}
                                 {!errorMessage &&
                                 <FilesFolderView
                                   path={path}


### PR DESCRIPTION
This fixes two issues, the "No such file or directory" view now shows the EmptyStatePanel properly centered and with the expected background colour. (The same background colour as the normal folder view.

Closes: #568

---

Expected pixel test failures: https://cockpit-logs.us-east-1.linodeobjects.com/pull-587-d56fe411-20240621-150917-fedora-40/log.html

Broken view:

![image](https://github.com/cockpit-project/cockpit-files/assets/67428/9d59830d-74cf-4a8f-a1c4-962ff154966d)

New view:

![image](https://github.com/cockpit-project/cockpit-files/assets/67428/70a42e1e-6a43-4b7a-a245-91b588e794bb)
