### PR TITLE
packit.yaml: don't release to Fedora-39

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -66,19 +66,16 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-development
-      - fedora-39
       - fedora-40
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-development
-      - fedora-39
       - fedora-40
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
-      - fedora-39
       - fedora-40


### PR DESCRIPTION
Fedora 41 is around the corner and as this is a relatively new package it does not make sense to push it to cockpit-files to Fedora 39.