### PR TITLE
package.json: drop unused devDependency on deep-equal

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "stylelint:fix": "stylelint --fix src/*{.css,scss}"
   },
   "devDependencies": {
-    "@types/deep-equal": "^1.0.4",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "@typescript-eslint/eslint-plugin": "7.13.1",
@@ -59,7 +58,6 @@
     "@patternfly/react-table": "5.3.3",
     "@patternfly/react-tokens": "5.3.1",
     "date-fns": "3.6.0",
-    "deep-equal": "2.2.3",
     "eslint-config-standard-react": "13.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",


### PR DESCRIPTION
Nothing in Files uses this.