### PR TITLE
Add summary to metainfo

### DIFF
--- a/org.cockpit-project.files.metainfo.xml
+++ b/org.cockpit-project.files.metainfo.xml
@@ -3,6 +3,7 @@
   <id>org.cockpit_project.cockpit_files</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Files</name>
+  <summary>Manage your files</summary>
   <description>
     <p>
         A file system browser for Cockpit.


### PR DESCRIPTION
As otherwise there is nothing filled in applications page:

![image](https://github.com/cockpit-project/cockpit-files/assets/1463740/454ecd99-0927-43ba-bd51-793fad023611)
