### PR TITLE
Properly handle non-latin1 filename in downloads

### DIFF
--- a/src/download.tsx
+++ b/src/download.tsx
@@ -22,7 +22,7 @@ import cockpit from 'cockpit';
 import type { FolderFileInfo } from './app';
 
 export function downloadFile(currentPath: string, selected: FolderFileInfo) {
-    const query = window.btoa(JSON.stringify({
+    const payload = JSON.stringify({
         payload: "fsread1",
         binary: "raw",
         path: `${currentPath}/${selected.name}`,
@@ -31,7 +31,10 @@ export function downloadFile(currentPath: string, selected: FolderFileInfo) {
             "content-disposition": `attachment; filename="${selected.name}"`,
             "content-type": "application/octet-stream",
         }
-    }));
+    });
+
+    const encodedPayload = new TextEncoder().encode(payload);
+    const query = window.btoa(String.fromCharCode(...encodedPayload));
 
     const prefix = (new URL(cockpit.transport.uri("channel/" + cockpit.transport.csrf_token))).pathname;
     window.open(`${prefix}?${query}`);

--- a/test/check-application
+++ b/test/check-application
@@ -718,6 +718,15 @@ class TestFiles(testlib.MachineCase):
         b.click(".contextMenu button:contains('Download')")
         self.waitDownloadFile("test.iso", 1500 * 1024 * 1024)
 
+        # non-latin1 file is fine
+        m.execute("echo 'non-latin filename' > /home/admin/漢字")
+        b.wait_visible("[data-item='漢字']")
+        b.mouse("[data-item='漢字']", "contextmenu")
+        b.click(".contextMenu button:contains('Download')")
+        size = int(self.stat('%s', '/home/admin/漢字'))
+        self.waitDownloadFile("漢字", size, "non-latin filename\n")
+        m.execute("rm /home/admin/漢字")
+
     def testRename(self) -> None:
         b = self.browser
         m = self.machine


### PR DESCRIPTION
So as described in #602, it isnt able to properly encode non-latin1 characters and `btoa` fails to encode it.

`TextEncoder` nets you the underlying utf8 bytes, which `btoa` is also not able to handle directly. But I did take @allisonkarlitskaya suggestion and didnt rely on `cockpit.base64_encode`, instead just apply every byte as its own character to btoa.

I have added a test, but I have tried to use the tasks container to run it, but I keep getting failures that I cant figure out. I think it is environmental issue, and has nothing to do with the test harness itself.