### PR TITLE
package.json: Clean up duplicate eslint-config-standard-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@patternfly/react-tokens": "5.3.1",
     "date-fns": "3.6.0",
     "dequal": "2.0.3",
-    "eslint-config-standard-react": "13.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "throttle-debounce": "5.0.0"


### PR DESCRIPTION
This is already in devDependencies. It has no place in the runtime dependencies.