### PR TITLE
Reset search filter on navigation

### DIFF
--- a/src/files-folder-view.tsx
+++ b/src/files-folder-view.tsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { Card } from '@patternfly/react-core/dist/esm/components/Card';
 
@@ -46,6 +46,11 @@ export const FilesFolderView = ({
     const [isGrid, setIsGrid] = useState(localStorage.getItem("files:isGrid") !== "false");
     const [sortBy, setSortBy] = useState(as_sort(localStorage.getItem("files:sort")));
     const onFilterChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => setCurrentFilter(value);
+
+    // Reset the search filter on path changes
+    useEffect(() => {
+        setCurrentFilter("");
+    }, [path]);
 
     return (
         <Card>

--- a/test/check-application
+++ b/test/check-application
@@ -357,6 +357,22 @@ class TestFiles(testlib.MachineCase):
         b.wait_val(path_input, "/")
         b.click(cancel_button)
 
+        # Navigating resets the current search filter
+        b.set_input_text("input[placeholder='Filter directory']", "sys")
+        self.browser.wait_js_cond("ph_count('#folder-view tbody tr') == 1")
+
+        b.mouse("[data-item='sys']", "dblclick")
+        b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "sys")
+        b.wait_val("input[placeholder='Filter directory']", "")
+
+        b.set_input_text("input[placeholder='Filter directory']", "no-matches-at-all")
+        self.browser.wait_js_cond("ph_count('#folder-view tbody tr') == 0")
+        b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "sys")
+
+        b.click(".breadcrumb-0")
+        b.wait_text("button.pf-m-disabled.breadcrumb-button + p", "/")
+        b.wait_val("input[placeholder='Filter directory']", "")
+
     def testSorting(self) -> None:
         b = self.browser
         m = self.machine


### PR DESCRIPTION
When a user clicks on a different path or double clicks a folder reset the search filter.