### PR TITLE
package.json: Drop date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@patternfly/react-styles": "5.3.1",
     "@patternfly/react-table": "5.3.3",
     "@patternfly/react-tokens": "5.3.1",
-    "date-fns": "3.6.0",
     "dequal": "2.0.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",


### PR DESCRIPTION
Since commit 34191c5ffcbcd45 nothing uses this dependency any more.