### PR TITLE
packaging: drop rhel8 specific BuildRequires

### DIFF
--- a/packaging/cockpit-files.spec.in
+++ b/packaging/cockpit-files.spec.in
@@ -16,9 +16,6 @@ BuildRequires:  appstream-glib
 BuildRequires:  libappstream-glib
 %endif
 BuildRequires: gettext
-%if 0%{?rhel} && 0%{?rhel} <= 8
-BuildRequires: libappstream-glib-devel
-%endif
 
 Requires: cockpit-bridge >= 318
 


### PR DESCRIPTION
Cockpit-files will never work on RHEL 8 as it needs a newer Cockpit (318 or higher).