### PR TITLE
test: Allow three column layout in testKeyboardNav

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1166,13 +1166,15 @@ class TestFiles(testlib.MachineCase):
         b.wait_visible("[data-item='file0'].row-selected")
 
         # Up / Down depends on the layout, this is tested on mobile where the
-        # width is two cards.
+        # width is two or three columns.
         b.set_layout("mobile")
         b.click("[data-item='file0']")
         b.wait_visible("[data-item='file0'].row-selected")
 
         b.key("ArrowDown")
-        b.wait_visible("[data-item='file2'].row-selected")
+        b.wait_js_cond("""ph_is_visible("[data-item='file2'].row-selected") ||
+                          ph_is_visible("[data-item='file3'].row-selected")""")
+
         b.key("ArrowUp")
         b.wait_visible("[data-item='file0'].row-selected")
 


### PR DESCRIPTION
It sometimes (RHEL 9 gating test) happens that the browser/mobile layout are set up so that three columns fit in one row. In this case, moving the cursor down lands at `file3`. Accept that as well.

---

This fixes one half of the RHEL 9 gating test failure. The [other half](https://artifacts.dev.testing-farm.io/2dbc2ef2-6c5e-430a-bbec-1039a5b6cc42/) (`testBookmark`) happens sometimes in upstream PRs as well, and looks like a race condition in either the code or the test.