### PR TITLE
fmf: Fix installation of our main-builds COPR

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -3,6 +3,17 @@
 set -eux
 cd "${0%/*}/../.."
 
+# if we run during cross-project testing against our main-builds COPR, then let that win
+# even if Fedora has a newer revision
+main_builds_repo="$(ls /etc/yum.repos.d/*cockpit*main-builds* 2>/dev/null || true)"
+if [ -n "$main_builds_repo" ]; then
+    echo 'priority=0' >> "$main_builds_repo"
+    dnf distro-sync -y --repo 'copr*' cockpit-files
+fi
+
+# Show critical package versions
+rpm -q cockpit-files cockpit-bridge
+
 . /usr/lib/os-release
 
 # allow test to set up things on the machine


### PR DESCRIPTION
If the env has a main-builds COPR (for reverse dependency tests), we always want to install the latest version from that. So give it the highest priority (uninutitively, lower priority wins), and use `distro-sync` to up- or downgrade the package as necessary, and consider *only* the COPR.

Also show the cockpit-{files,bridge} package versions in the log, to make this kind of failure cause more obvious.

Similar to https://github.com/cockpit-project/cockpit/commit/7ab102a551

----

This hopefully helps with the [random revdeps failures](https://artifacts.dev.testing-farm.io/7ad20935-9828-4cbc-81f7-40ee8c5b3ade/) which we are seeing. The log does not currently show the package version, but the failures smell like the main tests are running against an old cockpit-files rpm version.
