### PR TITLE
test: Do empty directory pixel test in controlled directory

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -106,9 +106,15 @@ class TestFiles(testlib.MachineCase):
         hidden_files_cnt = m.execute(r'ls -A /home/admin | grep "^\." | wc -l').strip()
         b.wait_text("#sidebar-card-header", f"admin{files_cnt} items ({hidden_files_cnt} hidden)")
 
-        # default directory is empty
+        # empty directory with one hidden file
+        m.execute("runuser -u admin mkdir /home/admin/empty")
+        m.execute("runuser -u admin touch /home/admin/empty/.hiddenfile")
+        b.mouse("[data-item='empty']", "dblclick")
         b.wait_text(".pf-v5-c-empty-state__body", "Directory is empty")
         b.assert_pixels(".pf-v5-c-page__main", "empty-folder-view")
+        b.click(".breadcrumb-2")  # go back to home dir
+        m.execute("rm -r /home/admin/empty")
+        b.wait_not_present("[data-item='empty']")
 
         # new files are auto-detected
         m.execute("touch --date @1641038400 /home/admin/newfile")


### PR DESCRIPTION
On the latest Fedora 40 image [1], /home/admin contains an extra `.bash_history` hidden file which breaks the "empty-folder-view" pixel test: there are now 5 instead of 4 hidden directories.

Do this pixel test in a self-created directory to make it more predictable.

[1] https://github.com/cockpit-project/bots/pull/6605

---

Fixes [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6605-f678fe28-20240711-051123-fedora-40-cockpit-project-cockpit-files/log.html).