### PR TITLE
Drop host name from navigation bar

### DIFF
--- a/src/files-breadcrumbs.tsx
+++ b/src/files-breadcrumbs.tsx
@@ -28,7 +28,7 @@ import { PageBreadcrumb } from "@patternfly/react-core/dist/esm/components/Page"
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { Tooltip, TooltipPosition } from "@patternfly/react-core/dist/esm/components/Tooltip";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
-import { CheckIcon, HddIcon, PencilAltIcon, StarIcon, TimesIcon } from "@patternfly/react-icons";
+import { CheckIcon, OutlinedHddIcon, PencilAltIcon, StarIcon, TimesIcon } from "@patternfly/react-icons";
 import { useInit } from "hooks.js";
 
 import cockpit from "cockpit";
@@ -278,7 +278,7 @@ export function FilesBreadcrumbs({ path, showHidden, setShowHidden }: { path: st
                         <React.Fragment key={fullPath.slice(0, i).join("/") || "/"}>
                             <Button
                               isDisabled={i === path.length - 1}
-                              icon={i === 0 ? <HddIcon /> : null}
+                              icon={i === 0 ? <OutlinedHddIcon /> : null}
                               variant="link" onClick={() => { navigate(i + 1) }}
                               className={`breadcrumb-button breadcrumb-${i}`}
                             >

--- a/test/check-application
+++ b/test/check-application
@@ -235,8 +235,7 @@ class TestFiles(testlib.MachineCase):
 
         self.enter_files()
 
-        hostname = m.execute("hostname").strip()
-        b.wait_text(".breadcrumb-0", hostname)
+        b.wait_text(".breadcrumb-0", "/")
         b.wait_text(".breadcrumb-1", "home")
         b.wait_text(".breadcrumb-2", "admin")
 
@@ -307,12 +306,6 @@ class TestFiles(testlib.MachineCase):
         b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "home")
         b.wait_visible("[data-item='admin']")
 
-        # Changing hostname updates breadcrumb
-        original_hostname = m.execute('hostnamectl hostname').strip()
-        self.addCleanup(m.execute, ['hostnamectl', 'set-hostname', original_hostname])
-        m.execute("hostnamectl set-hostname files")
-        b.wait_text(".breadcrumb-0", "files")
-
         # Navigation via editing the path
         path_input = "#new-path-input"
         edit_button = ".breadcrumb-button-edit"
@@ -366,7 +359,7 @@ class TestFiles(testlib.MachineCase):
         b.click(edit_button)
         b.set_input_text(path_input, "/")
         b.click(apply_button)
-        b.wait_text("button.pf-m-disabled.breadcrumb-button + p", "/")
+        b.wait_text("button.pf-m-disabled.breadcrumb-button", "/")
         b.click(edit_button)
         b.wait_val(path_input, "/")
         b.click(cancel_button)
@@ -384,7 +377,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_text(".pf-v5-c-page__main-breadcrumb > div > button:last-of-type", "sys")
 
         b.click(".breadcrumb-0")
-        b.wait_text("button.pf-m-disabled.breadcrumb-button + p", "/")
+        b.wait_text("button.pf-m-disabled.breadcrumb-button", "/")
         b.wait_val("input[placeholder='Filter directory']", "")
 
     def testSorting(self) -> None:


### PR DESCRIPTION
Showing the host name makes no sense in the context of navigating the file system tree. We don't have a concept of remote file systems, it just shows the local one. Also, the host name is already shown in the Shell.

Host names are often very long, taking away precious space especially in the mobile view. We already have an icon to represent the file system root. Add a "File system" ARIA label to that button make it accessible.

----

Looks like this now:

![image](https://github.com/user-attachments/assets/c7f51929-2d29-4087-8221-30856b67a031)

Also see the [updated pixel refs](https://github.com/cockpit-project/pixel-test-reference/compare/2e36736bab8c856cf5dfe2f2d22d321c6cbbaf8d..39d4d3a68b803887c70fca2bff53b490557cbba8). I'm fine with debating/changing the precise label of course.