### PR TITLE
manifest: drop content-security-policy

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,6 +12,5 @@
                 }
             ]
         }
-    },
-    "content-security-policy": "img-src 'self' data:; frame-src 'self' data:"
+    }
 }


### PR DESCRIPTION
The default content-security-policy of cockpit-bridge is enough for files it already includes `img-src: 'self' data:` and `frame-src` is not needed as we don't have or want any iframes or frames in files.

---

https://github.com/cockpit-project/cockpit/blob/main/src/cockpit/packages.py#L291