### PR TITLE
test: test the permissions dialog group selector

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1039,6 +1039,14 @@ class TestFiles(testlib.MachineCase):
         b.wait_text("#description-list-owner dd", "admin")
         b.wait_text("#description-list-group dd", "testuser")
 
+        # Change the group to admin
+        b.click("button:contains('Edit permissions')")
+        b.select_from_dropdown("#edit-permissions-group", "admin")
+        b.wait_in_text("#edit-permissions-group", "admin")
+        b.click("button.pf-m-primary")
+        b.wait_text("#description-list-owner dd", "admin")
+        b.wait_text("#description-list-group dd", "admin")
+
         # Test changing permissions
         b.click("button:contains('Edit permissions')")
         select_access("0")


### PR DESCRIPTION
We tested that the selector changed, but never tested setting the selector as a user, see coverage: https://cockpit-logs.us-east-1.linodeobjects.com/pull-661-2bb5c2bb-20240718-155256-fedora-40-devel/Coverage/src/dialogs/permissions.jsx.gcov.html