### PR TITLE
Keep the path as string instead of an array

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -53,7 +53,11 @@ export function * map_permissions<T>(func: (value: number, label: string) => T) 
 }
 
 export function basename(path: string) {
-    const elements = path.split('/');
+    if (path === '/') {
+        return path;
+    }
+
+    const elements = path.replace(/\/$/, '').split('/');
     if (elements.length === 0) {
         return '/';
     } else {

--- a/src/dialogs/permissions.jsx
+++ b/src/dialogs/permissions.jsx
@@ -32,7 +32,7 @@ import { etc_group_syntax, etc_passwd_syntax } from 'pam_user_parser';
 import { superuser } from 'superuser';
 
 import { useFilesContext } from '../app';
-import { map_permissions, inode_types } from '../common';
+import { map_permissions, inode_types, basename } from '../common';
 
 const _ = cockpit.gettext;
 
@@ -41,7 +41,7 @@ const EditPermissionsModal = ({ dialogResult, selected, path }) => {
 
     // Nothing selected means we act on the current working directory
     if (!selected) {
-        const directory_name = path[path.length - 1];
+        const directory_name = basename(path);
         selected = { ...cwdInfo, isCwd: true, name: directory_name };
     }
 
@@ -82,7 +82,7 @@ const EditPermissionsModal = ({ dialogResult, selected, path }) => {
         const ownerChanged = owner !== selected.user || group !== selected.group;
 
         try {
-            const directory = selected?.isCwd ? path.join("/") : path.join("/") + "/" + selected.name;
+            const directory = selected?.isCwd ? path : path + selected.name;
             if (permissionChanged)
                 await cockpit.spawn(["chmod", mode.toString(8), directory],
                                     { superuser: "try", err: "message" });

--- a/src/dialogs/rename.tsx
+++ b/src/dialogs/rename.tsx
@@ -74,7 +74,7 @@ function checkCanOverride(candidate: string, entries: Record<string, FileInfo>, 
 
 const RenameItemModal = ({ dialogResult, path, selected } : {
     dialogResult: DialogResult<void>
-    path: string[],
+    path: string,
     selected: FolderFileInfo,
 }) => {
     const { cwdInfo } = useFilesContext();
@@ -84,12 +84,12 @@ const RenameItemModal = ({ dialogResult, path, selected } : {
     const [overrideFileName, setOverrideFileName] = useState(false);
 
     const renameItem = (force = false) => {
-        const newPath = path.join("/") + "/" + name;
+        const newPath = path + name;
         const mvCmd = ["mv", "--no-target-directory"];
         if (force) {
             mvCmd.push("--force");
         }
-        mvCmd.push(path.join("/") + "/" + selected.name, newPath);
+        mvCmd.push(path + selected.name, newPath);
 
         cockpit.spawn(mvCmd, { superuser: "try", err: "message" })
                 .then(() => {
@@ -167,6 +167,6 @@ const RenameItemModal = ({ dialogResult, path, selected } : {
     );
 };
 
-export function show_rename_dialog(dialogs: Dialogs, path: string[], selected: FolderFileInfo) {
+export function show_rename_dialog(dialogs: Dialogs, path: string, selected: FolderFileInfo) {
     dialogs.run(RenameItemModal, { path, selected });
 }

--- a/src/files-card-body.tsx
+++ b/src/files-card-body.tsx
@@ -75,7 +75,7 @@ function compare(sortBy: Sort): (a: FolderFileInfo, b: FolderFileInfo) => number
 }
 
 const ContextMenuItems = ({ path, selected, setSelected, clipboard, setClipboard } : {
-    path: string[],
+    path: string,
     selected: FolderFileInfo[], setSelected: React.Dispatch<React.SetStateAction<FolderFileInfo[]>>,
     clipboard: string[], setClipboard: React.Dispatch<React.SetStateAction<string[]>>,
 }) => {
@@ -124,7 +124,7 @@ export const FilesCardBody = ({
     setCurrentFilter: React.Dispatch<React.SetStateAction<string>>,
     files: FolderFileInfo[],
     isGrid: boolean,
-    path: string[],
+    path: string,
     selected: FolderFileInfo[], setSelected: React.Dispatch<React.SetStateAction<FolderFileInfo[]>>,
     sortBy: Sort, setSortBy: React.Dispatch<React.SetStateAction<Sort>>,
     loadingFiles: boolean,
@@ -159,7 +159,7 @@ export const FilesCardBody = ({
     }
 
     const onDoubleClickNavigate = useCallback((file: FolderFileInfo) => {
-        const newPath = [...path, file.name].join("/");
+        const newPath = path + file.name;
         if (file.to === "dir") {
             cockpit.location.go("/", { path: encodeURIComponent(newPath) });
         }
@@ -281,7 +281,7 @@ export const FilesCardBody = ({
             } else if (e.key === "Enter" && selected.length === 1) {
                 onDoubleClickNavigate(selected[0]);
             } else if (e.key === "Delete" && selected.length !== 0) {
-                confirm_delete(dialogs, path.join("/") + "/", selected, setSelected);
+                confirm_delete(dialogs, path, selected, setSelected);
             }
         };
 

--- a/src/files-folder-view.tsx
+++ b/src/files-folder-view.tsx
@@ -37,7 +37,7 @@ export const FilesFolderView = ({
     setClipboard,
     setShowHidden,
 }: {
-    path: string[],
+    path: string,
     files: FolderFileInfo[],
     loadingFiles: boolean,
     showHidden: boolean,

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -124,7 +124,7 @@ export const FilesCardHeader = ({
     isGrid: boolean, setIsGrid: React.Dispatch<React.SetStateAction<boolean>>,
     sortBy: Sort, setSortBy: React.Dispatch<React.SetStateAction<Sort>>
     showHidden: boolean, setShowHidden: React.Dispatch<React.SetStateAction<boolean>>,
-    path: string[],
+    path: string,
 }) => {
     return (
         <CardHeader className="card-actionbar">

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -45,14 +45,13 @@ type MenuItem = { type: "divider" } | {
 };
 
 export function get_menu_items(
-    path: string[],
+    path: string,
     selected: FolderFileInfo[], setSelected: React.Dispatch<React.SetStateAction<FolderFileInfo[]>>,
     clipboard: string[], setClipboard: React.Dispatch<React.SetStateAction<string[]>>,
     cwdInfo: FileInfo | null,
     addAlert: (title: string, variant: AlertVariant, key: string, detail?: string) => void,
     dialogs: Dialogs,
 ) {
-    const currentPath = path.join("/") + "/";
     const menuItems: MenuItem[] = [];
 
     if (selected.length === 0) {
@@ -73,7 +72,7 @@ export function get_menu_items(
                         "cp",
                         "-R",
                         ...clipboard,
-                        currentPath
+                        path
                     ]).catch(err => addAlert(err.message, AlertVariant.danger, `${new Date().getTime()}`));
                 }
             },
@@ -81,7 +80,7 @@ export function get_menu_items(
             {
                 id: "create-item",
                 title: _("Create directory"),
-                onClick: () => show_create_directory_dialog(dialogs, currentPath)
+                onClick: () => show_create_directory_dialog(dialogs, path)
             },
             { type: "divider" },
             {
@@ -95,7 +94,7 @@ export function get_menu_items(
             {
                 id: "copy-item",
                 title: _("Copy"),
-                onClick: () => setClipboard([currentPath + selected[0].name]),
+                onClick: () => setClipboard([path + selected[0].name]),
             },
             { type: "divider" },
             {
@@ -113,7 +112,7 @@ export function get_menu_items(
                 id: "delete-item",
                 title: _("Delete"),
                 className: "pf-m-danger",
-                onClick: () => confirm_delete(dialogs, currentPath, selected, setSelected)
+                onClick: () => confirm_delete(dialogs, path, selected, setSelected)
             },
         );
         if (selected[0].type === "reg")
@@ -122,7 +121,7 @@ export function get_menu_items(
                 {
                     id: "download-item",
                     title: _("Download"),
-                    onClick: () => downloadFile(currentPath, selected[0])
+                    onClick: () => downloadFile(path, selected[0])
                 }
             );
     } else if (selected.length > 1) {
@@ -130,13 +129,13 @@ export function get_menu_items(
             {
                 id: "copy-item",
                 title: _("Copy"),
-                onClick: () => setClipboard(selected.map(s => path.join("/") + "/" + s.name)),
+                onClick: () => setClipboard(selected.map(s => path + s.name)),
             },
             {
                 id: "delete-item",
                 title: _("Delete"),
                 className: "pf-m-danger",
-                onClick: () => confirm_delete(dialogs, currentPath, selected, setSelected)
+                onClick: () => confirm_delete(dialogs, path, selected, setSelected)
             }
         );
     }

--- a/src/sidebar.tsx
+++ b/src/sidebar.tsx
@@ -37,7 +37,7 @@ import { useDialogs } from "dialogs";
 import * as timeformat from "timeformat";
 
 import { FolderFileInfo, useFilesContext } from "./app";
-import { get_permissions } from "./common";
+import { basename, get_permissions } from "./common";
 import { edit_permissions } from "./dialogs/permissions";
 import { get_menu_items } from "./menu";
 
@@ -93,7 +93,7 @@ function getDescriptionListItems(selected: FolderFileInfo) {
 
 export const SidebarPanelDetails = ({ files, path, selected, setSelected, showHidden, clipboard, setClipboard } : {
     files: FolderFileInfo[],
-    path: string[],
+    path: string,
     selected: FolderFileInfo[], setSelected: React.Dispatch<React.SetStateAction<FolderFileInfo[]>>,
     showHidden: boolean,
     clipboard: string[], setClipboard: React.Dispatch<React.SetStateAction<string[]>>
@@ -103,7 +103,7 @@ export const SidebarPanelDetails = ({ files, path, selected, setSelected, showHi
 
     useEffect(() => {
         if (selected.length === 1) {
-            const filePath = path.join("/") + "/" + selected[0]?.name;
+            const filePath = path + selected[0]?.name;
 
             cockpit.spawn(["file", "--brief", filePath], { superuser: "try", err: "message" })
                     .then(res => setInfo(res?.trim()))
@@ -112,7 +112,7 @@ export const SidebarPanelDetails = ({ files, path, selected, setSelected, showHi
     }, [path, selected]);
 
     const dialogs = useDialogs();
-    const directory_name = path[path.length - 1];
+    const directory_name = basename(path);
     const hidden_count = files.filter(file => file.name.startsWith(".")).length;
     let shown_items = cockpit.format(cockpit.ngettext("$0 item", "$0 items", files.length), files.length);
     if (!showHidden)

--- a/src/upload-button.tsx
+++ b/src/upload-button.tsx
@@ -55,7 +55,7 @@ const FileConflictDialog = ({
     isMultiUpload,
     dialogResult
 }: {
-    path: string[];
+    path: string;
     file: FileInfo,
     uploadFile: File,
     isMultiUpload: boolean,
@@ -96,7 +96,7 @@ const FileConflictDialog = ({
             <p>
                 {cockpit.format(
                     _("A file with the same name already exists in \"$0\". Replacing it will overwrite its content."),
-                    path.join('/')
+                    path
                 )}
             </p>
             <Flex
@@ -129,7 +129,7 @@ const FileConflictDialog = ({
 export const UploadButton = ({
     path,
 } : {
-    path: string[],
+    path: string,
 }) => {
     const ref = useRef<HTMLInputElement>(null);
     const { addAlert, cwdInfo } = useFilesContext();
@@ -209,9 +209,7 @@ export const UploadButton = ({
 
         const cancelledUploads = [];
         await Promise.allSettled(toUploadFiles.map(async (file: File) => {
-            const tmp_path = path.slice();
-            tmp_path.push(file.name);
-            const destination = tmp_path.join('/');
+            const destination = path + file.name;
             const abort = new AbortController();
 
             setUploadedFiles(oldFiles => {

--- a/test/check-application
+++ b/test/check-application
@@ -260,6 +260,10 @@ class TestFiles(testlib.MachineCase):
         b.wait_in_text(".pf-v5-c-empty-state__body", "No such file or directory")
         b.wait_visible("#dropdown-menu:disabled")
 
+        # Path with multiple slashes is normalized
+        b.go("/files#/?path=/////")
+        b.wait_text("li[data-location='/']", "")
+
     def testNavigation(self) -> None:
         b = self.browser
         m = self.machine
@@ -346,7 +350,7 @@ class TestFiles(testlib.MachineCase):
 
         # Via escape
         b.click(edit_button)
-        b.wait_val(path_input, "/home")
+        b.wait_val(path_input, "/home/")
         b.set_input_text(path_input, "/home/admin")
         b.wait_visible(path_input)
         b.focus(path_input)
@@ -356,7 +360,7 @@ class TestFiles(testlib.MachineCase):
         # Via cancel button
         b.click(edit_button)
         # Cancelled edit should not save the path
-        b.wait_val(path_input, "/home")
+        b.wait_val(path_input, "/home/")
         b.click(cancel_button)
         b.wait_not_present(path_input)
 
@@ -382,7 +386,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_not_present(path_input)
         b.click(edit_button)
         b.wait_visible(path_input)
-        b.wait_val(path_input, "/var")
+        b.wait_val(path_input, "/var/")
         b.click(cancel_button)
 
         # Editing / shows / in the input
@@ -1193,7 +1197,7 @@ class TestFiles(testlib.MachineCase):
         b.click("button:contains('Edit permissions')")
         select_access("7")
         b.click("button.pf-m-primary")
-        self.wait_modal_inline_alert("chmod: changing permissions of '//home': Operation not permitted")
+        self.wait_modal_inline_alert("chmod: changing permissions of '/home': Operation not permitted")
         b.click("button.pf-m-link")
         b.wait_not_present(".pf-v5-c-modal-box")
 
@@ -1832,6 +1836,7 @@ class TestFiles(testlib.MachineCase):
             b.wait_not_present(".pf-v5-c-menu .pf-v5-c-menu__list-item")
 
         b.click("#bookmark-btn")
+        # There is only one menu item
         b.wait_in_text(".pf-v5-c-menu .pf-v5-c-menu__list-item", "Home")
         # Home directory cannot be added or removed as bookmark
         b.wait_not_present(".pf-v5-c-menu .pf-v5-c-menu__list-item:contains(Add bookmark)")
@@ -1894,7 +1899,7 @@ class TestFiles(testlib.MachineCase):
         b.click(".pf-v5-c-menu .pf-v5-c-menu__list-item:contains(Add bookmark) button")
 
         assert_bookmark("This is a-test", exists=True)
-        self.assertIn("file:///home/admin/This%20is%20a-test\n", read_config())
+        self.assertIn("file:///home/admin/This%20is%20a-test/\n", read_config())
 
         # Removing /tmp bookmark keeps bookmark with spaces
         b.click("#bookmark-btn")
@@ -1906,7 +1911,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_not_present(".pf-v5-c-menu")
 
         assert_bookmark("/tmp", exists=False)
-        self.assertEqual(read_config(), "file:///etc\nfile:///home/admin/This%20is%20a-test\n")
+        self.assertEqual(read_config(), "file:///etc/\nfile:///home/admin/This%20is%20a-test/\n")
 
         # Add a directory with special characters
         special_dir = "super#special*1 2><.,ß"
@@ -1920,7 +1925,7 @@ class TestFiles(testlib.MachineCase):
         b.click(".pf-v5-c-menu .pf-v5-c-menu__list-item:contains(Add bookmark) button")
 
         assert_bookmark(special_dir, exists=True)
-        self.assertEqual("file:///etc\nfile:///home/admin/This%20is%20a-test\nfile:///home/admin/super%23special*1%202%3E%3C.%2C%C3%9F\n",
+        self.assertEqual("file:///etc/\nfile:///home/admin/This%20is%20a-test/\nfile:///home/admin/super%23special*1%202%3E%3C.%2C%C3%9F/\n",
                          read_config())
 
         b.click("li[data-location='/home/admin'] a")
@@ -1935,7 +1940,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_not_present(".pf-v5-c-menu")
 
         assert_bookmark(special_dir, exists=False)
-        self.assertEqual(read_config(), "file:///etc\nfile:///home/admin/This%20is%20a-test\n")
+        self.assertEqual(read_config(), "file:///etc/\nfile:///home/admin/This%20is%20a-test/\n")
 
         # Modifications outside of Cockpit are shown
         m.execute("""


### PR DESCRIPTION
There is no good reason to keep the path as an array of strings, usually we want to just append a file to the path for file operations as most of the code simply joined the path back to a string.

This also makes sure the path is properly formatted as /path/to/thing/ with a leading and trailing /.

---

* [x] Merge https://github.com/cockpit-project/cockpit-files/pull/670 as this will conflict.
* [x] To Do, also handle users providing paths as `///` and `///foo///`