### PR TITLE
Add owner column to details view

### DIFF
--- a/src/files-card-body.scss
+++ b/src/files-card-body.scss
@@ -198,6 +198,7 @@
 
         .col-size, .item-size,
         .col-date, .item-date,
+        .col-owner, .item-owner,
         .col-perms, .item-perms {
             inline-size: 12ch;
             text-align: end;
@@ -205,7 +206,7 @@
 
         // Remove the extra padding on the end of the column and button, as the icon has padding already
         .col-size, .col-date,
-        .col-perms {
+        .col-perms, .col-owner {
             &, .pf-v5-c-table__button {
                 padding-inline-end: 0;
             }
@@ -281,7 +282,7 @@
                 color: var(--pf-v5-global--Color--200);
             }
 
-            .item-date, .item-perms {
+            .item-date, .item-perms, .item-owner {
                 display: none;
             }
 

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -42,6 +42,8 @@ export enum Sort {
     smallest_size = 'smallest_size',
     first_modified = 'first_modified',
     last_modified = 'last_modified',
+    owner_asc = 'owner_asc',
+    owner_desc = 'owner_desc',
     most_permissive = 'most_permissive',
     least_permissive = 'least_permissive',
 }
@@ -86,6 +88,17 @@ export const filterColumns = [
         [SortByDirection.desc]: {
             itemId: Sort.last_modified,
             label: _("Last modified"),
+        },
+    },
+    {
+        title: _("Owner"),
+        [SortByDirection.asc]: {
+            itemId: Sort.owner_asc,
+            label: _("Owner ascending"),
+        },
+        [SortByDirection.desc]: {
+            itemId: Sort.owner_desc,
+            label: _("Owner descending"),
         },
     },
     {

--- a/test/check-application
+++ b/test/check-application
@@ -618,6 +618,139 @@ class TestFiles(testlib.MachineCase):
         b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "BBB")
         b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "ccc")
 
+        # create test users
+        m.execute("""
+        useradd barusr
+        useradd cmanusr
+        useradd foousr
+        useradd qusr
+        useradd rebelusr
+        """)
+
+        # Sorting by file ownership
+        # Files are primarily sorted by user
+        m.execute(f"""
+        chown admin:root {basedir}/aaa
+        chown foousr:root {basedir}/BBB
+        chown barusr:root {basedir}/ccc
+        chown qusr:foousr {basedir}/eee
+        chown rebelusr:cmanusr {basedir}/Eee
+        """)
+        b.click("th button:contains(Owner)")
+
+        # Verify order
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "Eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "ddd")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "BBB")
+
+        # Verify owner is displayed correctly
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-owner", "qusr:foousr")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-owner", "rebelusr:cmanusr")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-owner", "root")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-owner", "admin:root")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-owner", "barusr:root")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-owner", "foousr:root")
+
+        # Reverse sorting
+        b.click("th button:contains(Owner)")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "ddd")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "Eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "aaa")
+
+        # Files are sorted by group when user is the same
+        m.execute(f"""
+        chown admin:root {basedir}/aaa
+        chown admin:foousr {basedir}/BBB
+        chown admin:rebelusr {basedir}/ccc
+        chown --no-dereference admin:rebelusr {basedir}/ddd
+        chown admin:foousr {basedir}/eee
+        chown admin:admin {basedir}/Eee
+        """)
+        b.click("th button:contains(Owner)")
+
+        # Verify order
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "Eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "ddd")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "aaa")
+
+        # Verify owner is displayed correctly
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-owner", "admin")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-owner", "admin:foousr")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-owner", "admin:rebelusr")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-owner", "admin:foousr")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-owner", "admin:rebelusr")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-owner", "admin:root")
+
+        # Reverse sorting
+        b.click("th button:contains(Owner)")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "ddd")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "Eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "BBB")
+
+        # Sorting falls back to file name sort
+        m.execute(f"""
+        chown admin:admin {basedir}/aaa
+        chown admin:admin {basedir}/BBB
+        chown admin:admin {basedir}/ccc
+        chown admin:admin {basedir}/eee
+        chown admin:admin {basedir}/Eee
+        """)
+        b.click("th button:contains(Owner)")
+
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "Eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "ddd")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "ccc")
+
+        # Sorting when UID is a number
+        # Numbers are sorted after known names
+        m.execute(f"""
+        chown foousr:admin {basedir}/aaa
+        chown foousr:568 {basedir}/BBB
+        chown foousr:admin {basedir}/ccc
+        chown foousr:admin {basedir}/eee
+        chown 569:admin {basedir}/Eee
+        chown --no-dereference 568:admin {basedir}/ddd
+        """)
+
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "ddd")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "Eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "aaa")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "BBB")
+
+        # Verify owner is displayed correctly
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-owner", "foousr:admin")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-owner", "568:admin")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-owner", "569:admin")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-owner", "foousr:admin")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-owner", "foousr:admin")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-owner", "foousr:568")
+
+        # Reverse
+        b.click("th button:contains(Owner)")
+        b.wait_text("#folder-view tbody tr:nth-of-type(1) .item-name", "Eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(2) .item-name", "ddd")
+        b.wait_text("#folder-view tbody tr:nth-of-type(3) .item-name", "eee")
+        b.wait_text("#folder-view tbody tr:nth-of-type(4) .item-name", "BBB")
+        b.wait_text("#folder-view tbody tr:nth-of-type(5) .item-name", "ccc")
+        b.wait_text("#folder-view tbody tr:nth-of-type(6) .item-name", "aaa")
+
     def testDelete(self) -> None:
         b = self.browser
         m = self.machine
@@ -1213,7 +1346,7 @@ class TestFiles(testlib.MachineCase):
 
         def check_perms_match(file: str, basedir: str) -> None:
             ls = m.execute(f"ls -l {basedir}/{file}")[:10]
-            ui = b.text(f"[data-item='{file}'] td:nth-child(4) pre").replace(" ", "")
+            ui = b.text(f"[data-item='{file}'] .item-perms pre").replace(" ", "")
             self.assertEqual(ls[1:], ui)
 
         # Simple permissions


### PR DESCRIPTION
Fixes: #580

- [x] How to display and sort when user/group is a number
- [x] test for user/group is a number

Sorting is currently as follows:
- directories first
- by user
- by group
- filename

I'd like to think about if we should sort current user first (as #580 mentions), I'm not sure if I like the idea but I want to check it out.