### PR TITLE
test: Fix race in TestFiles.testUpload

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1570,7 +1570,7 @@ class TestFiles(testlib.MachineCase):
             # Verify ownership
             filename = os.path.basename(files[0])
             b.click(f"[data-item='{filename}']")
-            b.wait_text("#sidebar-card-header", filename)
+            b.wait_text("#sidebar-card-header h2", filename)
             b.wait_text("#description-list-owner dd", "admin")
             b.wait_text("#description-list-group dd", "admin")
 


### PR DESCRIPTION
The `#sidebar-card-header` also contains the file type, which appears a moment after clicking on the file name. Make the selector more specific to not include the file type component.

---

Fixes [this flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-700-f64d734e-20240811-193008-debian-testing/log.html#17-1), which became very apparent in #700.