### PR TITLE
packit: Add Fedora 41

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -24,8 +24,9 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
+      - fedora-40
+      - fedora-41
       - fedora-development
-      - fedora-latest-stable
       - fedora-latest-stable-aarch64
       - centos-stream-9-x86_64
       - centos-stream-10
@@ -33,8 +34,9 @@ jobs:
   - job: tests
     trigger: pull_request
     targets:
+      - fedora-40
+      - fedora-41
       - fedora-development
-      - fedora-latest-stable
       - fedora-latest-stable-aarch64
       - centos-stream-9-x86_64
       - centos-stream-10
@@ -69,17 +71,20 @@ jobs:
   - job: propose_downstream
     trigger: release
     dist_git_branches:
-      - fedora-development
       - fedora-40
+      - fedora-41
+      - fedora-development
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
-      - fedora-development
       - fedora-40
+      - fedora-41
+      - fedora-development
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
       - fedora-40
+      - fedora-41


### PR DESCRIPTION
Also replace "latest-stable" with a more direct "40". We do that in all other projects, and there's less ambiguity during times when a release was forked, but isn't declared "stable" yet.