### PR TITLE
css: move CSS declarations above nested rules

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -33,13 +33,13 @@
 }
 
 .pf-v5-c-page__main {
+    gap: var(--pf-v5-global--spacer--md);
     display: grid;
     grid-template:
         "topbar topbar topbar topbar" auto
         ". content sidebar ." 1fr
         ". . . ." 0
         / 0 1fr 18rem 0;
-    gap: var(--pf-v5-global--spacer--md);
     inline-size: 100vw;
     block-size: 100vh;
 }
@@ -72,16 +72,15 @@
 
 .files-overview-header {
   grid-area: topbar;
+  gap: var(--pf-v5-global--spacer--sm);
+  display: flex;
+  /* Align page breadcrumb centered */
+  align-items: center;
 
     /* Override different background color from the <PageBreadCrumb> */
   .pf-v5-c-page__main-breadcrumb {
       background-color: unset
   }
-
-  gap: var(--pf-v5-global--spacer--sm);
-  display: flex;
-  /* Align page breadcrumb centered */
-  align-items: center;
 
   /* Drop PF padding */
   .pf-v5-c-page__main-breadcrumb {


### PR DESCRIPTION
The new SASS version warns that decelerations should appear above nested rules. This change should not have any visual impact.

> ▲ [WARNING] Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`.