### PR TITLE
test: Fix timeout for waitDownloadFile()

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -86,8 +86,7 @@ class TestFiles(testlib.MachineCase):
         filepath = b.driver.download_dir / filename
 
         # Big downloads can take a while
-        with b.wait_timeout(120):
-            testlib.wait(filepath.exists)
+        testlib.wait(filepath.exists, tries=120)
         if expected_size is not None:
             testlib.wait(lambda: filepath.stat().st_size == expected_size)
 


### PR DESCRIPTION
This [fixes rhel-9-5 runs](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6760-6cb82890-20240819-124109-rhel-9-5-cockpit-project-cockpit-files/log.html) (see https://github.com/cockpit-project/bots/pull/6760) and also tightens a check.

I triggered an extra [rhel-9-5 run](https://cockpit-logs.us-east-1.linodeobjects.com/pull-713-0bae87a9-20240819-132012-rhel-9-5/log.html) here (it's currently in _manual).