### PR TITLE
test: fix attempts to write files as admin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ exclude = [
 strict = true
 warn_return_any = false # https://github.com/python/mypy/issues/17380
 
+[tool.pyright]
+strict = ["**"]
+extraPaths = ["test/common", "bots"]
+
 [tool.ruff]
 exclude = [
     ".git/",

--- a/test/check-application
+++ b/test/check-application
@@ -2012,7 +2012,7 @@ class TestFiles(testlib.MachineCase):
 
         # Bookmarks from nautilus are supported
         m.execute("runuser -u admin mkdir '/home/admin/This is a-test'")
-        m.write('/home/admin/.config/gtk-3.0/bookmarks',
+        m.write(config_file,
                 "file:///home/admin/This%20is%20a%2dtest\n"
                 "file:///tmp Temporary Directory\n",
                 append=True, owner='admin:admin')
@@ -2076,7 +2076,7 @@ class TestFiles(testlib.MachineCase):
         self.assertEqual(read_config(), "file:///etc/\nfile:///home/admin/This%20is%20a-test/\n")
 
         # Modifications outside of Cockpit are shown
-        m.write('/home/admin/.config/gtk-3.0/bookmarks',
+        m.write(config_file,
                 "nfs://lalala\n"
                 "file:///var\n",
                 append=True, owner='admin:admin')
@@ -2088,14 +2088,14 @@ class TestFiles(testlib.MachineCase):
         self.assert_last_breadcrumb("var")
 
         # Removing bookmarks file removes all bookmarks
-        m.execute("rm -rf /home/admin/.config/gtk-3.0/bookmarks")
+        m.execute(['rm', '-rf', config_file])
         b.click("#bookmark-btn")
         b.wait_not_present(".pf-v5-c-menu .pf-v5-c-menu__list-item:contains('/etc') button")
         b.click("#bookmark-btn")
         b.wait_not_present(".pf-v5-c-menu")
 
         # Remove a bookmark when the directory is removed
-        m.write('/home/admin/.config/gtk-3.0/bookmarks',
+        m.write(config_file,
                 "file:///tmp/non-existent\n",
                 owner='admin:admin')
 
@@ -2107,7 +2107,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_not_present(".pf-v5-c-menu")
         # Removing the last bookmark, empties the file
         testlib.wait(lambda: m.execute(
-                        "if ! test -e /home/admin/.config/gtk-3.0/bookmarks; then echo gone; fi").strip() == "gone")
+                        f"if ! test -e {config_file}; then echo gone; fi").strip() == "gone")
 
         b.click("#bookmark-btn")
         b.wait_not_present(".pf-v5-c-menu .pf-v5-c-menu__list-item:contains('Add bookmark') button")

--- a/test/check-application
+++ b/test/check-application
@@ -1549,10 +1549,8 @@ class TestFiles(testlib.MachineCase):
         self.enter_files()
 
         # Copy/paste file
-        m.execute("""
-            runuser -u admin mkdir /home/admin/newdir
-            runuser -u admin echo "test_text" > /home/admin/newfile
-        """)
+        m.execute("runuser -u admin mkdir /home/admin/newdir")
+        m.write('/home/admin/newfile', 'test_text\n', owner='admin:admin')
         b.click("[data-item='newfile']")
         b.click("#dropdown-menu")
         b.click("#copy-item")
@@ -1585,7 +1583,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_visible("[data-item='copyDir']")
 
         # File already exists error
-        m.execute("runuser -u admin echo 'changed' > /home/admin/newfile")
+        m.write('/home/admin/newfile', 'changed', owner='admin:admin')
         b.click("[data-item='newfile']")
         b.click("#dropdown-menu")
         b.click("#copy-item")
@@ -2013,11 +2011,11 @@ class TestFiles(testlib.MachineCase):
         self.assert_last_breadcrumb("etc")
 
         # Bookmarks from nautilus are supported
-        m.execute("""
-            runuser -u admin mkdir '/home/admin/This is a-test'
-            runuser -u admin echo "file:///home/admin/This%20is%20a%2dtest" >> /home/admin/.config/gtk-3.0/bookmarks
-            runuser -u admin echo "file:///tmp Temporary Directory" >> /home/admin/.config/gtk-3.0/bookmarks
-        """)
+        m.execute("runuser -u admin mkdir '/home/admin/This is a-test'")
+        m.write('/home/admin/.config/gtk-3.0/bookmarks',
+                "file:///home/admin/This%20is%20a%2dtest\n"
+                "file:///tmp Temporary Directory\n",
+                append=True, owner='admin:admin')
         b.click("#bookmark-btn")
         b.click(".pf-v5-c-menu .pf-v5-c-menu__list-item:contains('This is a-test') button")
         self.assert_last_breadcrumb("This is a-test")
@@ -2078,10 +2076,10 @@ class TestFiles(testlib.MachineCase):
         self.assertEqual(read_config(), "file:///etc/\nfile:///home/admin/This%20is%20a-test/\n")
 
         # Modifications outside of Cockpit are shown
-        m.execute("""
-            runuser -u admin echo "nfs://lalala" >> /home/admin/.config/gtk-3.0/bookmarks
-            runuser -u admin echo "file:///var" >> /home/admin/.config/gtk-3.0/bookmarks
-        """)
+        m.write('/home/admin/.config/gtk-3.0/bookmarks',
+                "nfs://lalala\n"
+                "file:///var\n",
+                append=True, owner='admin:admin')
 
         b.click("#bookmark-btn")
         b.click(".pf-v5-c-menu .pf-v5-c-menu__list-item:contains('/var') button")
@@ -2097,7 +2095,10 @@ class TestFiles(testlib.MachineCase):
         b.wait_not_present(".pf-v5-c-menu")
 
         # Remove a bookmark when the directory is removed
-        m.execute("runuser -u admin echo 'file:///tmp/non-existent' > /home/admin/.config/gtk-3.0/bookmarks")
+        m.write('/home/admin/.config/gtk-3.0/bookmarks',
+                "file:///tmp/non-existent\n",
+                owner='admin:admin')
+
         b.click("#bookmark-btn")
         b.click(".pf-v5-c-menu .pf-v5-c-menu__list-item:contains('non-existent') button")
         self.assert_last_breadcrumb("non-existent")


### PR DESCRIPTION
We have a lot of cases of this pattern in the tests:

```sh
   runuser -u admin echo something > /some/file
```

which successfully runs the 'echo' command as the admin user, but performs the redirection (and therefore file creation) as root, which is clearly not the desired result.
    
Change those over to use m.write() with the `owner=` kwarg.
