### PR TITLE
all: change approach to extensions on imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
     "plugins": ["react", "react-hooks", "jsx-a11y"],
     "rules": {
         "array-bracket-newline": ["error", { "multiline": true }],
-        "import/extensions": ["error", "never", { "json": "always" }],
+        "import/extensions": ["error", "ignorePackages"],
         "import/order": ["error",
             {
                 "alphabetize": { "order": "asc" },

--- a/build.js
+++ b/build.js
@@ -7,12 +7,12 @@ import process from 'node:process';
 
 import copy from 'esbuild-plugin-copy';
 
-import { cockpitPoEsbuildPlugin } from './pkg/lib/cockpit-po-plugin';
-import { cockpitRsyncEsbuildPlugin } from './pkg/lib/cockpit-rsync-plugin';
-import { cleanPlugin } from './pkg/lib/esbuild-cleanup-plugin';
-import { esbuildStylesPlugins } from './pkg/lib/esbuild-common';
-import { cockpitCompressPlugin } from './pkg/lib/esbuild-compress-plugin';
-import { filetype_plugin } from './src/filetype-plugin';
+import { cockpitPoEsbuildPlugin } from './pkg/lib/cockpit-po-plugin.js';
+import { cockpitRsyncEsbuildPlugin } from './pkg/lib/cockpit-rsync-plugin.js';
+import { cleanPlugin } from './pkg/lib/esbuild-cleanup-plugin.js';
+import { esbuildStylesPlugins } from './pkg/lib/esbuild-common.js';
+import { cockpitCompressPlugin } from './pkg/lib/esbuild-compress-plugin.js';
+import { filetype_plugin } from './src/filetype-plugin.ts';
 
 const useWasm = os.arch() !== 'x64';
 const esbuild = (await import(useWasm ? 'esbuild-wasm' : 'esbuild')).default;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -28,17 +28,17 @@ import { Sidebar, SidebarPanel, SidebarContent } from "@patternfly/react-core/di
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
 
 import cockpit from "cockpit";
-import { FsInfoClient, FileInfo } from "cockpit/fsinfo";
+import { FsInfoClient, FileInfo } from "cockpit/fsinfo.ts";
 import { EmptyStatePanel } from "cockpit-components-empty-state";
 import { WithDialogs } from "dialogs";
 import { usePageLocation } from "hooks";
 import { superuser } from "superuser";
 
-import { FilesBreadcrumbs } from "./files-breadcrumbs";
-import { FilesFolderView } from "./files-folder-view";
-import filetype_data from './filetype-data';
-import { filetype_lookup } from './filetype-lookup';
-import { SidebarPanelDetails } from "./sidebar";
+import { FilesBreadcrumbs } from "./files-breadcrumbs.tsx";
+import { FilesFolderView } from "./files-folder-view.tsx";
+import filetype_data from './filetype-data'; // eslint-disable-line import/extensions
+import { filetype_lookup } from './filetype-lookup.ts';
+import { SidebarPanelDetails } from "./sidebar.tsx";
 
 superuser.reload_page_on_change();
 

--- a/src/dialogs/mkdir.tsx
+++ b/src/dialogs/mkdir.tsx
@@ -32,8 +32,8 @@ import { InlineNotification } from 'cockpit-components-inline-notification';
 import type { Dialogs, DialogResult } from 'dialogs';
 import { superuser } from 'superuser';
 
-import { useFilesContext } from '../app';
-import { get_owner_candidates } from '../ownership';
+import { useFilesContext } from '../app.tsx';
+import { get_owner_candidates } from '../ownership.tsx';
 
 const _ = cockpit.gettext;
 

--- a/src/dialogs/permissions.jsx
+++ b/src/dialogs/permissions.jsx
@@ -31,8 +31,8 @@ import { useInit } from 'hooks';
 import { etc_group_syntax, etc_passwd_syntax } from 'pam_user_parser';
 import { superuser } from 'superuser';
 
-import { useFilesContext } from '../app';
-import { map_permissions, inode_types, basename } from '../common';
+import { useFilesContext } from '../app.tsx';
+import { map_permissions, inode_types, basename } from '../common.ts';
 
 const _ = cockpit.gettext;
 

--- a/src/dialogs/rename.tsx
+++ b/src/dialogs/rename.tsx
@@ -26,13 +26,13 @@ import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput'
 import { Stack } from '@patternfly/react-core/dist/esm/layouts/Stack';
 
 import cockpit from 'cockpit';
-import { FileInfo } from "cockpit/fsinfo";
+import { FileInfo } from "cockpit/fsinfo.ts";
 import { FormHelper } from 'cockpit-components-form-helper';
 import { InlineNotification } from 'cockpit-components-inline-notification';
 import type { Dialogs, DialogResult } from 'dialogs';
 import { fmt_to_fragments } from 'utils';
 
-import { FolderFileInfo, useFilesContext } from '../app';
+import { FolderFileInfo, useFilesContext } from '../app.tsx';
 
 const _ = cockpit.gettext;
 

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -19,7 +19,7 @@
 
 import cockpit from 'cockpit';
 
-import type { FolderFileInfo } from './app';
+import type { FolderFileInfo } from './app.ts';
 
 export function downloadFile(currentPath: string, selected: FolderFileInfo) {
     const payload = JSON.stringify({

--- a/src/files-breadcrumbs.tsx
+++ b/src/files-breadcrumbs.tsx
@@ -28,12 +28,12 @@ import { PageBreadcrumb, PageSection, PageSectionVariants } from "@patternfly/re
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { Tooltip, TooltipPosition } from "@patternfly/react-core/dist/esm/components/Tooltip";
 import { CheckIcon, OutlinedHddIcon, PencilAltIcon, StarIcon, TimesIcon } from "@patternfly/react-icons";
-import { useInit } from "hooks.js";
 
 import cockpit from "cockpit";
+import { useInit } from "hooks";
 
-import { useFilesContext } from "./app";
-import { basename } from "./common";
+import { useFilesContext } from "./app.tsx";
+import { basename } from "./common.ts";
 
 const _ = cockpit.gettext;
 

--- a/src/files-card-body.tsx
+++ b/src/files-card-body.tsx
@@ -34,11 +34,11 @@ import { EmptyStatePanel } from "cockpit-components-empty-state";
 import { useDialogs } from "dialogs";
 import * as timeformat from "timeformat";
 
-import { FolderFileInfo, useFilesContext } from "./app";
-import { get_permissions } from "./common";
-import { confirm_delete } from "./dialogs/delete";
-import { Sort, filterColumnMapping, filterColumns } from "./header";
-import { get_menu_items } from "./menu";
+import { FolderFileInfo, useFilesContext } from "./app.tsx";
+import { get_permissions } from "./common.ts";
+import { confirm_delete } from "./dialogs/delete.tsx";
+import { Sort, filterColumnMapping, filterColumns } from "./header.tsx";
+import { get_menu_items } from "./menu.tsx";
 
 import "./files-card-body.scss";
 

--- a/src/files-folder-view.tsx
+++ b/src/files-folder-view.tsx
@@ -22,9 +22,9 @@ import React, { useEffect, useState } from "react";
 import { Card } from '@patternfly/react-core/dist/esm/components/Card';
 import { debounce } from "throttle-debounce";
 
-import type { FolderFileInfo } from "./app";
-import { FilesCardBody } from "./files-card-body";
-import { as_sort, FilesCardHeader } from "./header";
+import type { FolderFileInfo } from "./app.tsx";
+import { FilesCardBody } from "./files-card-body.tsx";
+import { as_sort, FilesCardHeader } from "./header.tsx";
 
 export const FilesFolderView = ({
     path,

--- a/src/filetype-data.d.ts
+++ b/src/filetype-data.d.ts
@@ -1,4 +1,4 @@
-import type { FileTypeData } from './filetype-lookup';
+import type { FileTypeData } from './filetype-lookup.ts';
 
 /* This data comes dynamically as JSON from filetype-plugin.ts */
 declare const filetype_data: FileTypeData;

--- a/src/filetype-plugin.ts
+++ b/src/filetype-plugin.ts
@@ -24,11 +24,11 @@
  * with the return value of the `create_filetype_data()` function`.
  */
 
-import { Plugin, PluginBuild } from 'esbuild';
-import language_map from 'language-map';
-import mime_db from 'mime-db/db.json';
+import type { Plugin, PluginBuild } from 'esbuild';
+import language_map from 'language-map' with { type: 'json' };
+import mime_db from 'mime-db/db.json' with { type: 'json' };
 
-import { Category, FileTypeData } from './filetype-lookup.ts';
+import { Category, type FileTypeData } from './filetype-lookup.ts';
 
 export function create_filetype_data() : FileTypeData {
     const categories = {

--- a/src/filetype-plugin.ts
+++ b/src/filetype-plugin.ts
@@ -28,7 +28,7 @@ import { Plugin, PluginBuild } from 'esbuild';
 import language_map from 'language-map';
 import mime_db from 'mime-db/db.json';
 
-import { Category, FileTypeData } from './filetype-lookup';
+import { Category, FileTypeData } from './filetype-lookup.ts';
 
 export function create_filetype_data() : FileTypeData {
     const categories = {

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -31,7 +31,7 @@ import { SortByDirection } from '@patternfly/react-table';
 
 import cockpit from "cockpit";
 
-import { UploadButton } from "./upload-button";
+import { UploadButton } from "./upload-button.tsx";
 
 const _ = cockpit.gettext;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,7 +24,7 @@ import React from "react";
 
 import { createRoot } from "react-dom/client";
 
-import { Application } from "./app";
+import { Application } from "./app.tsx";
 
 /*
  * PF4 overrides need to come after the JSX components imports because

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -26,12 +26,12 @@ import type { FileInfo } from "cockpit/fsinfo";
 import type { Dialogs } from 'dialogs';
 
 import type { FolderFileInfo } from "./app";
-import { basename } from "./common";
-import { confirm_delete } from './dialogs/delete';
-import { show_create_directory_dialog } from './dialogs/mkdir';
-import { edit_permissions } from './dialogs/permissions';
-import { show_rename_dialog } from './dialogs/rename';
-import { downloadFile } from './download';
+import { basename } from "./common.ts";
+import { confirm_delete } from './dialogs/delete.tsx';
+import { show_create_directory_dialog } from './dialogs/mkdir.tsx';
+import { edit_permissions } from './dialogs/permissions.jsx';
+import { show_rename_dialog } from './dialogs/rename.tsx';
+import { downloadFile } from './download.tsx';
 
 const _ = cockpit.gettext;
 

--- a/src/ownership.tsx
+++ b/src/ownership.tsx
@@ -1,5 +1,5 @@
 import cockpit from 'cockpit';
-import type { FileInfo } from 'cockpit/fsinfo';
+import type { FileInfo } from 'cockpit/fsinfo.ts';
 
 // Determine the potential ownerships that a new item created in a particular
 // directory might have, in case we have admin access.  If superuser mode is

--- a/src/sidebar.tsx
+++ b/src/sidebar.tsx
@@ -36,10 +36,10 @@ import { KebabDropdown } from "cockpit-components-dropdown";
 import { useDialogs } from "dialogs";
 import * as timeformat from "timeformat";
 
-import { FolderFileInfo, useFilesContext } from "./app";
-import { basename, get_permissions } from "./common";
-import { edit_permissions } from "./dialogs/permissions";
-import { get_menu_items } from "./menu";
+import { FolderFileInfo, useFilesContext } from "./app.tsx";
+import { basename, get_permissions } from "./common.ts";
+import { edit_permissions } from "./dialogs/permissions.jsx";
+import { get_menu_items } from "./menu.tsx";
 
 const _ = cockpit.gettext;
 

--- a/src/upload-button.tsx
+++ b/src/upload-button.tsx
@@ -36,7 +36,7 @@ import { DialogResult, useDialogs } from "dialogs";
 import * as timeformat from "timeformat";
 import { fmt_to_fragments } from "utils";
 
-import { useFilesContext } from "./app";
+import { useFilesContext } from "./app.tsx";
 
 import "./upload-button.scss";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "paths": {
         "*": ["./pkg/lib/*"]
     },
+    "module": "preserve",
     "moduleResolution": "bundler",
     "noEmit": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "allowJs": true,
     "checkJs": true,
     "exactOptionalPropertyTypes": true,


### PR DESCRIPTION
It's currently not possible to run ./build.js under node-22, which is a shame, because we'll want to be able to do that soon (due to upcoming TypeScript support, which will let us stop using tsx and its bundled copy of esbuild, simplifying builds on arm64).

Reading the developments on the addition of TypeScript support to Node, it seems to be the case that TypeScript is somewhat isolated in their opinion on the correct approach for handling extensions on import statements.  Indeed, node-22 will outright break if we don't use extensions correctly.

Add back the extensions that we removed from the files in our build process.  Change our use of the eslint rule to *require* extensions, rather than forbid them, and update our code accordingly.  Updating our bundled code is not strictly necessary (and we could just drop the eslint rule entirely) but let's be consistent.

Add an option to our tsconfig to tell TypeScript that we want to do things node's way.