### PR TITLE
Re-use basename from cockpit's new path lib

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -51,16 +51,3 @@ export function * map_permissions<T>(func: (value: number, label: string) => T) 
         yield func(value, label);
     }
 }
-
-export function basename(path: string) {
-    if (path === '/') {
-        return path;
-    }
-
-    const elements = path.replace(/\/$/, '').split('/');
-    if (elements.length === 0) {
-        return '/';
-    } else {
-        return elements[elements.length - 1];
-    }
-}

--- a/src/dialogs/permissions.jsx
+++ b/src/dialogs/permissions.jsx
@@ -27,12 +27,13 @@ import { Stack } from '@patternfly/react-core/dist/esm/layouts/Stack';
 
 import cockpit from 'cockpit';
 import { InlineNotification } from 'cockpit-components-inline-notification';
+import { basename } from "cockpit-path";
 import { useInit } from 'hooks';
 import { etc_group_syntax, etc_passwd_syntax } from 'pam_user_parser';
 import { superuser } from 'superuser';
 
 import { useFilesContext } from '../app.tsx';
-import { map_permissions, inode_types, basename } from '../common.ts';
+import { map_permissions, inode_types } from '../common.ts';
 
 const _ = cockpit.gettext;
 

--- a/src/files-breadcrumbs.tsx
+++ b/src/files-breadcrumbs.tsx
@@ -30,10 +30,10 @@ import { Tooltip, TooltipPosition } from "@patternfly/react-core/dist/esm/compon
 import { CheckIcon, OutlinedHddIcon, PencilAltIcon, StarIcon, TimesIcon } from "@patternfly/react-icons";
 
 import cockpit from "cockpit";
+import { basename } from "cockpit-path";
 import { useInit } from "hooks";
 
 import { useFilesContext } from "./app.tsx";
-import { basename } from "./common.ts";
 
 const _ = cockpit.gettext;
 

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -23,10 +23,10 @@ import { AlertVariant } from "@patternfly/react-core/dist/esm/components/Alert";
 
 import cockpit from "cockpit";
 import type { FileInfo } from "cockpit/fsinfo";
+import { basename } from "cockpit-path";
 import type { Dialogs } from 'dialogs';
 
 import type { FolderFileInfo } from "./app";
-import { basename } from "./common.ts";
 import { confirm_delete } from './dialogs/delete.tsx';
 import { edit_file, MAX_EDITOR_FILE_SIZE } from './dialogs/editor.tsx';
 import { show_create_directory_dialog } from './dialogs/mkdir.tsx';

--- a/src/sidebar.tsx
+++ b/src/sidebar.tsx
@@ -33,11 +33,12 @@ import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/esm
 
 import cockpit from "cockpit";
 import { KebabDropdown } from "cockpit-components-dropdown";
+import { basename } from "cockpit-path";
 import { useDialogs } from "dialogs";
 import * as timeformat from "timeformat";
 
 import { FolderFileInfo, useFilesContext } from "./app.tsx";
-import { basename, get_permissions } from "./common.ts";
+import { get_permissions } from "./common.ts";
 import { edit_permissions } from "./dialogs/permissions.jsx";
 import { get_menu_items } from "./menu.tsx";
 


### PR DESCRIPTION
Drop our own implementation in favour of the shared cockpit-lib one.