### PR TITLE
test: drop outdated comment about size not changing

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -168,7 +168,6 @@ class TestFiles(testlib.MachineCase):
         b.wait_text("#description-list-last-modified dd", "Jan 1, 2022, 12:00 PM")
 
         # saving a file updates sidebar info
-        # FIXME: Size does not update
         m.execute("head -c 7 /dev/zero > /home/admin/newfile")
         b.wait_text("#description-list-size dd", "7 B")
         b.wait_not_in_text("#description-list-last-modified ", "Jan 1, 2022, 12:00 PM")


### PR DESCRIPTION
The test checks that the size changes from 0 => 7 B so this is an outdated comment.