### PR TITLE
dialogs: unify the dialog titles

### DIFF
--- a/src/dialogs/delete.tsx
+++ b/src/dialogs/delete.tsx
@@ -25,6 +25,7 @@ import { Modal, ModalVariant } from '@patternfly/react-core/dist/esm/components/
 import cockpit from 'cockpit';
 import { InlineNotification } from 'cockpit-components-inline-notification';
 import type { Dialogs, DialogResult } from 'dialogs';
+import { fmt_to_fragments } from 'utils';
 
 import type { FolderFileInfo } from '../app';
 
@@ -40,23 +41,25 @@ const ConfirmDeletionDialog = ({ dialogResult, path, selected, setSelected } : {
 
     let modalTitle;
     if (selected.length > 1) {
-        modalTitle = cockpit.format(forceDelete ? _("Force delete $0 items") : _("Delete $0 items?"), selected.length);
+        const selectedJSX = <b>{selected.length}</b>;
+        modalTitle = fmt_to_fragments(forceDelete ? _("Force delete $0 items") : _("Delete $0 items?"), selectedJSX);
     } else {
         const selectedItem = selected[0];
+        const selectedJSX = <b>{selectedItem.name}</b>;
         if (selectedItem.type === "reg") {
-            modalTitle = cockpit.format(
-                forceDelete ? _("Force delete file $0?") : _("Delete file $0?"), selectedItem.name
+            modalTitle = fmt_to_fragments(
+                forceDelete ? _("Force delete file $0?") : _("Delete file $0?"), selectedJSX
             );
         } else if (selectedItem.type === "lnk") {
-            modalTitle = cockpit.format(
-                forceDelete ? _("Force delete link $0?") : _("Delete link $0?"), selectedItem.name
+            modalTitle = fmt_to_fragments(
+                forceDelete ? _("Force delete link $0?") : _("Delete link $0?"), selectedJSX
             );
         } else if (selectedItem.type === "dir") {
-            modalTitle = cockpit.format(
-                forceDelete ? _("Force delete directory $0?") : _("Delete directory $0?"), selectedItem.name
+            modalTitle = fmt_to_fragments(
+                forceDelete ? _("Force delete directory $0?") : _("Delete directory $0?"), selectedJSX
             );
         } else {
-            modalTitle = cockpit.format(forceDelete ? _("Force delete $0") : _("Delete $0?"), selectedItem.name);
+            modalTitle = fmt_to_fragments(forceDelete ? _("Force delete $0") : _("Delete $0?"), selectedJSX);
         }
     }
 

--- a/src/dialogs/editor.tsx
+++ b/src/dialogs/editor.tsx
@@ -30,6 +30,7 @@ import { debounce } from "throttle-debounce";
 import cockpit from 'cockpit';
 import { EventEmitter } from 'cockpit/event.ts';
 import type { Dialogs, DialogResult } from 'dialogs';
+import { fmt_to_fragments } from 'utils';
 
 import "./editor.scss";
 
@@ -165,7 +166,7 @@ export const EditFileModal = ({ dialogResult, path } : {
     };
 
     /* Translators: This is the title of a modal dialog.  $0 represents a filename. */
-    let title = <>{cockpit.format(state?.writable ? _("Edit “$0”") : _("View “$0”"), path)}</>;
+    let title = <>{fmt_to_fragments(state?.writable ? _("Edit $0") : _("View $0"), <b>{path}</b>)}</>;
     if (!state.writable) {
         // TODO: dark mode and lack of spacing
         title = (<>{title}<Label className="file-editor-title-label" variant="filled">{_("Read-only")}</Label></>);

--- a/src/dialogs/permissions.jsx
+++ b/src/dialogs/permissions.jsx
@@ -31,6 +31,7 @@ import { basename } from "cockpit-path";
 import { useInit } from 'hooks';
 import { etc_group_syntax, etc_passwd_syntax } from 'pam_user_parser';
 import { superuser } from 'superuser';
+import { fmt_to_fragments } from 'utils.tsx';
 
 import { useFilesContext } from '../app.tsx';
 import { map_permissions, inode_types } from '../common.ts';
@@ -119,7 +120,7 @@ const EditPermissionsModal = ({ dialogResult, selected, path }) => {
           position="top"
           variant={ModalVariant.small}
           /* Translators: $0 represents a filename */
-          title={cockpit.format(_("“$0” permissions"), selected.name)}
+          title={fmt_to_fragments(_("$0 permissions"), <b>{selected.name}</b>)}
           description={inode_types[selected.type] || "Unknown type"}
           isOpen
           onClose={dialogResult.resolve}

--- a/test/check-application
+++ b/test/check-application
@@ -2292,7 +2292,7 @@ class TestFiles(testlib.MachineCase):
 
         # Opening an test file, editing and closing (discard)
         open_editor("test.txt")
-        b.wait_text(".pf-v5-c-modal-box__title", "Edit “/home/admin/test.txt”")
+        b.wait_text(".pf-v5-c-modal-box__title", "Edit /home/admin/test.txt")
         b.wait_text(".file-editor-modal textarea", "test\n")
 
         # Save button is disabled when not editing yet
@@ -2401,7 +2401,7 @@ class TestFiles(testlib.MachineCase):
         b.go("/files#/?path=/etc")
         self.assert_last_breadcrumb("etc")
         open_editor("cockpit-files-test.cfg")
-        b.wait_text(".pf-v5-c-modal-box__title", "View “/etc/cockpit-files-test.cfg”Read-only")
+        b.wait_text(".pf-v5-c-modal-box__title", "View /etc/cockpit-files-test.cfgRead-only")
         b.assert_pixels(".file-editor-modal", "editor-modal-read-only")
 
         b.click(".pf-v5-c-modal-box__footer button.pf-m-secondary")


### PR DESCRIPTION
Unify them to all use the form `$action <b>$name</b>` so all dialog titles use the same style.

---

#### Editor

![image](https://github.com/user-attachments/assets/c380ebd3-f76a-4b95-88d3-e78bdce50508)

#### Delete

![image](https://github.com/user-attachments/assets/d76a0bd5-7313-41e3-88f1-68c03e1bda95)


#### Rename

![image](https://github.com/user-attachments/assets/96b3f25b-9bba-47c6-be23-524ad9f1a2d7)


##### Permissions

![image](https://github.com/user-attachments/assets/245f9a5e-a2bc-4804-aedb-a0d98bae6007)
