### PR TITLE
Support downloading with the multi-host feature

### DIFF
--- a/src/download.tsx
+++ b/src/download.tsx
@@ -27,6 +27,7 @@ export function downloadFile(currentPath: string, selected: FolderFileInfo) {
         binary: "raw",
         path: `${currentPath}/${selected.name}`,
         superuser: "try",
+        host: cockpit.transport.host,
         external: {
             "content-disposition": `attachment; filename="${selected.name}"`,
             "content-type": "application/octet-stream",


### PR DESCRIPTION
This fixes trying to download a remotely connected host, without setting the host header the fsread1 request will go to the "shell host" and not the currently viewed machine.

Closes: #773