### PR TITLE
appstream: Fix validation problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TARFILE=$(RPM_NAME)-$(VERSION).tar.xz
 NODE_CACHE=$(RPM_NAME)-node-$(VERSION).tar.xz
 SPEC=$(RPM_NAME).spec
 PREFIX ?= /usr/local
-APPSTREAMFILE=org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
+APPSTREAMFILE=org.cockpit_project.$(PACKAGE_NAME).metainfo.xml
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check for node_modules/
 NODE_MODULES_TEST=package-lock.json

--- a/org.cockpit_project.files.metainfo.xml
+++ b/org.cockpit_project.files.metainfo.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.cockpit_project.cockpit_files</id>
+  <id>org.cockpit_project.files</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Files</name>
   <summary>Manage your files</summary>
   <description>
     <p>
-        A file system browser for Cockpit.
+        A file system UI for Cockpit.
+
+        You can browse directories, upload and download files, and change their properties.
+        It also includes a simple file editor.
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
@@ -14,4 +17,7 @@
   <url type="homepage">https://github.com/cockpit-project/cockpit-files</url>
   <url type="bugtracker">https://github.com/cockpit-project/cockpit-files/issues</url>
   <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
+  <developer id="org.cockpit-project">
+    <name>Cockpit Project</name>
+  </developer>
 </component>


### PR DESCRIPTION
Rename the file to match its ID, fix the ID, add developer tag, and extend the description. This fixes all issues with `appstreamcli validate`:

> org.cockpit-project.files.metainfo.xml
>  I: org.cockpit_project.cockpit_files:22: description-first-para-too-short
>       A file system browser for Cockpit.
>  I: org.cockpit_project.cockpit_files: developer-info-missing
>  W: org.cockpit_project.cockpit_files: metainfo-filename-cid-mismatch