### PR TITLE
package.json: require nodejs 16 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "git@github.com:cockpit-project/cockpit-files.git",
   "author": "",
   "license": "LGPL-2.1",
+  "engines": {
+    "node": ">= 18"
+  },
   "scripts": {
     "watch": "./build.js -w",
     "build": "./build.js",


### PR DESCRIPTION
Copied from starter-kit.


Hopefully avoids issues like https://github.com/cockpit-project/cockpit-files/issues/791

Fixes #791