### PR TITLE
Create file support

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -18,6 +18,9 @@
  */
 
 import cockpit from "cockpit";
+import { FileInfo } from "cockpit/fsinfo";
+
+import { FolderFileInfo } from "./app";
 
 const _ = cockpit.gettext;
 
@@ -73,4 +76,23 @@ export function permissionShortStr(mode: number) {
     }
 
     return permsStr.join(" ");
+}
+
+export function checkFilename(candidate: string, entries: Record<string, FileInfo>, selectedFile?: FolderFileInfo) {
+    if (candidate === "") {
+        return _("Name cannot be empty");
+    } else if (candidate.length >= 256) {
+        return _("Name too long");
+    } else if (candidate.includes("/")) {
+        return _("Name cannot include a /");
+    } else if (selectedFile && selectedFile.name === candidate) {
+        return _("Filename is the same as original name");
+    } else if (candidate in entries) {
+        if (entries[candidate].type === "dir") {
+            return _("Directory with the same name exists");
+        }
+        return _("File exists");
+    } else {
+        return null;
+    }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -18,9 +18,9 @@
  */
 
 import cockpit from "cockpit";
-import { FileInfo } from "cockpit/fsinfo";
+import { FileInfo } from "cockpit/fsinfo.ts";
 
-import { FolderFileInfo } from "./app";
+import { FolderFileInfo } from "./app.ts";
 
 const _ = cockpit.gettext;
 

--- a/src/dialogs/create-file.tsx
+++ b/src/dialogs/create-file.tsx
@@ -1,0 +1,235 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import { Alert, AlertVariant } from '@patternfly/react-core/dist/esm/components/Alert';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
+import { Modal, ModalVariant } from '@patternfly/react-core/dist/esm/components/Modal';
+import { TextArea } from '@patternfly/react-core/dist/esm/components/TextArea';
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { Stack } from '@patternfly/react-core/dist/esm/layouts/Stack';
+
+import cockpit from 'cockpit';
+import { FormHelper } from 'cockpit-components-form-helper';
+import type { Dialogs, DialogResult } from 'dialogs';
+import { useInit } from 'hooks';
+import { superuser } from 'superuser';
+
+import "./editor.scss";
+import { useFilesContext } from '../app.tsx';
+import { checkFilename } from '../common.ts';
+import { get_owner_candidates } from '../ownership.tsx';
+
+const _ = cockpit.gettext;
+
+async function create_file(filename: string, content?: string, owner?: string | null) {
+    const file = cockpit.file(filename, { superuser: "try" });
+
+    try {
+        await file.replace("");
+    } catch (err) {
+        console.warn("Cannot create new file", err);
+        throw err;
+    }
+
+    if (owner) {
+        try {
+            await cockpit.spawn(["chown", owner, filename], { superuser: "require" });
+        } catch (err) {
+            console.warn("Cannot chown new file", err);
+            try {
+                await cockpit.spawn(["rm", filename], { superuser: "require" });
+            } catch (err) {
+                console.warn(`Failed to cleanup ${filename}`, err);
+            }
+            throw err;
+        }
+    }
+
+    if (content) {
+        // We need to obtain the tag to retain file ownership
+        // Can't do this async because we can't get the tag via await
+        await cockpit.file(filename, { superuser: "try" }).read()
+                .then(((async (_content: string, tag: string) => {
+                    try {
+                        await cockpit.file(filename, { superuser: "try" }).replace(content, tag);
+                    } catch (err) {
+                        console.warn("Cannot set initial file text", err);
+                        try {
+                            await cockpit.spawn(["rm", filename], { superuser: "require" });
+                        } catch (err) {
+                            console.warn(`Failed to cleanup ${filename}`, err);
+                        }
+                        throw err;
+                    }
+                }) as any /* eslint-disable-line @typescript-eslint/no-explicit-any */));
+    }
+}
+
+const CreateFileModal = ({ dialogResult, path } : {
+    dialogResult: DialogResult<string | null>,
+    path: string
+}) => {
+    const [filename, setFilename] = React.useState<string>("");
+    const [owner, setOwner] = React.useState<string | null>(null);
+    const [initialText, setInitialText] = React.useState<string>("");
+    const [filenameError, setFileNameError] = React.useState<string | null>(null);
+    const [createError, setCreateError] = React.useState<string | null>(null);
+    const [candidates, setCandidates] = React.useState<string[]>([]);
+
+    const { cwdInfo } = useFilesContext();
+
+    useInit(() => {
+        cockpit.user().then(user => {
+            const owner_candidates = [];
+            if (superuser.allowed && cwdInfo) {
+                owner_candidates.push(...get_owner_candidates(user, cwdInfo));
+                setOwner(owner_candidates[0]);
+                setCandidates(owner_candidates);
+            }
+        });
+    });
+
+    const handleEscape = (event: KeyboardEvent) => {
+        if (filename !== "" || initialText !== "") {
+            event.preventDefault();
+        } else {
+            dialogResult.resolve(null);
+        }
+    };
+
+    const handleSave = async () => {
+        cockpit.assert(filename, "filename undefined");
+        const filename_valid = checkFilename(filename, cwdInfo?.entries || {}, undefined);
+        if (filename_valid !== null) {
+            setFileNameError(filename_valid);
+            return;
+        }
+
+        const full_path = path + filename;
+        try {
+            await create_file(full_path, initialText, owner);
+        } catch (err) {
+            const exc = err as cockpit.BasicError; // HACK: You can't easily type an error in typescript
+            setCreateError(exc.message);
+            return;
+        }
+
+        dialogResult.resolve(full_path);
+    };
+
+    if (superuser.allowed && owner === undefined)
+        return null;
+
+    return (
+        <Modal
+          position="top"
+          title={_("Create file")}
+          isOpen
+          onClose={() => dialogResult.resolve(null)}
+          variant={ModalVariant.large}
+          className="file-create-modal"
+          onEscapePress={handleEscape}
+          footer={
+              <>
+                  <Button
+                    variant="primary"
+                    isDisabled={!filename || initialText === "" || filenameError !== null}
+                    onClick={handleSave}
+                  >
+                      {_("Create")}
+                  </Button>
+                  <Button variant="link" onClick={() => dialogResult.resolve(null)}>
+                      {_("Cancel")}
+                  </Button>
+              </>
+          }
+        >
+            <Stack>
+                {createError &&
+                <Alert
+                  className="file-editor-alert"
+                  variant="danger"
+                  title={createError}
+                  isInline
+                />}
+                <Form isHorizontal>
+                    <FormGroup
+                      label={_("File name")}
+                      fieldId="file-name"
+                    >
+                        <TextInput
+                          autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+                          id="file-name"
+                          isRequired
+                          value={filename}
+                          onChange={(_event, value) => {
+                              setFileNameError(checkFilename(value, cwdInfo?.entries || {}, undefined));
+                              setFilename(value);
+                          }}
+                        />
+                        <FormHelper fieldId="file-name" helperTextInvalid={filenameError} />
+                    </FormGroup>
+                    <TextArea
+                      id="editor-text-area"
+                      className="file-editor"
+                      value={initialText}
+                      onChange={(_ev, content) => setInitialText(content)}
+                    />
+                    {candidates.length > 0 &&
+                        <FormGroup fieldId="create-file-owner" label={_("Owner")}>
+                            <FormSelect
+                              id="create-file-owner"
+                              value={owner}
+                              onChange={(_ev, val) => setOwner(val)}
+                            >
+                                {candidates.map(owner =>
+                                    <FormSelectOption
+                                      key={owner}
+                                      value={owner}
+                                      label={owner}
+                                    />)}
+                            </FormSelect>
+                        </FormGroup>}
+                </Form>
+            </Stack>
+        </Modal>
+    );
+};
+
+export async function show_create_file_dialog(
+    dialogs: Dialogs,
+    path: string,
+    addAlert: (title: string, variant: AlertVariant, key: string, detail?: string) => void
+) {
+    if (!superuser.allowed) {
+        try {
+            await cockpit.spawn(["test", "-w", path]);
+        } catch {
+            addAlert(_("Cannot create file in current directory"), AlertVariant.warning, "create-file",
+                     _("Permission denied"));
+            return;
+        }
+    }
+
+    await dialogs.run(CreateFileModal, { path });
+}

--- a/src/dialogs/editor.scss
+++ b/src/dialogs/editor.scss
@@ -1,4 +1,4 @@
-.file-editor-modal {
+.file-editor-modal, .file-create-modal {
   block-size: 100%;
 
   &.is-modified {
@@ -21,6 +21,12 @@
       display: inline-block;
       margin-inline-start: 0.5cap;
     }
+  }
+
+  // Create mode shows textarea as full size
+  .pf-v5-c-form.pf-m-horizontal {
+    block-size: 100%;
+    grid-template-rows: auto 1fr auto;
   }
 }
 

--- a/src/dialogs/editor.tsx
+++ b/src/dialogs/editor.tsx
@@ -169,7 +169,6 @@ export const EditFileModal = ({ dialogResult, path } : {
     /* Translators: This is the title of a modal dialog.  $0 represents a filename. */
     let title = <>{fmt_to_fragments(state?.writable ? _("Edit $0") : _("View $0"), <b>{basename(path)}</b>)}</>;
     if (!state.writable) {
-        // TODO: dark mode and lack of spacing
         title = (<>{title}<Label className="file-editor-title-label" variant="filled">{_("Read-only")}</Label></>);
     }
 

--- a/src/dialogs/rename.tsx
+++ b/src/dialogs/rename.tsx
@@ -33,27 +33,9 @@ import type { Dialogs, DialogResult } from 'dialogs';
 import { fmt_to_fragments } from 'utils';
 
 import { FolderFileInfo, useFilesContext } from '../app.tsx';
+import { checkFilename } from '../common.ts';
 
 const _ = cockpit.gettext;
-
-function checkName(candidate: string, entries: Record<string, FileInfo>, selectedFile: FolderFileInfo) {
-    if (candidate === "") {
-        return _("Name cannot be empty");
-    } else if (candidate.length >= 256) {
-        return _("Name too long");
-    } else if (candidate.includes("/")) {
-        return _("Name cannot include a /");
-    } else if (selectedFile.name === candidate) {
-        return _("Filename is the same as original name");
-    } else if (candidate in entries) {
-        if (entries[candidate].type === "dir") {
-            return _("Directory with the same name exists");
-        }
-        return _("File exists");
-    } else {
-        return null;
-    }
-}
 
 function checkCanOverride(candidate: string, entries: Record<string, FileInfo>, selectedFile: FolderFileInfo) {
     if (candidate in entries) {
@@ -141,7 +123,7 @@ const RenameItemModal = ({ dialogResult, path, selected } : {
                       if (name !== selected.name)
                           renameItem();
                       else {
-                          setNameError(checkName(name, cwdInfo?.entries || {}, selected));
+                          setNameError(checkFilename(name, cwdInfo?.entries || {}, selected));
                       }
                       return false;
                   }}
@@ -151,7 +133,7 @@ const RenameItemModal = ({ dialogResult, path, selected } : {
                           autoFocus // eslint-disable-line jsx-a11y/no-autofocus
                           value={name}
                           onChange={(_, val) => {
-                              setNameError(checkName(val, cwdInfo?.entries || {}, selected));
+                              setNameError(checkFilename(val, cwdInfo?.entries || {}, selected));
                               setOverrideFileName(checkCanOverride(val, cwdInfo?.entries || {}, selected));
                               setErrorMessage(undefined);
                               setName(val);

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -27,6 +27,7 @@ import { basename } from "cockpit-path";
 import type { Dialogs } from 'dialogs';
 
 import type { FolderFileInfo } from "./app";
+import { show_create_file_dialog } from './dialogs/create-file.tsx';
 import { confirm_delete } from './dialogs/delete.tsx';
 import { edit_file, MAX_EDITOR_FILE_SIZE } from './dialogs/editor.tsx';
 import { show_create_directory_dialog } from './dialogs/mkdir.tsx';
@@ -89,6 +90,11 @@ export function get_menu_items(
                 id: "create-folder",
                 title: _("Create directory"),
                 onClick: () => show_create_directory_dialog(dialogs, path)
+            },
+            {
+                id: "create-file",
+                title: _("Create file"),
+                onClick: () => show_create_file_dialog(dialogs, path, addAlert)
             },
             { type: "divider" },
             {

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -86,7 +86,7 @@ export function get_menu_items(
             },
             { type: "divider" },
             {
-                id: "create-item",
+                id: "create-folder",
                 title: _("Create directory"),
                 onClick: () => show_create_directory_dialog(dialogs, path)
             },

--- a/test/check-application
+++ b/test/check-application
@@ -62,7 +62,7 @@ class TestFiles(testlib.MachineCase):
     def create_directory(self, filename: str, owner: str | None = None, *, expect_success: bool = True) -> None:
         b = self.browser
         b.click("#dropdown-menu")
-        b.click("#create-item")
+        b.click("#create-folder")
         b.set_input_text("#create-directory-input", f"{filename}")
         if owner:
             b.select_from_dropdown("#create-directory-owner", owner)
@@ -861,7 +861,7 @@ class TestFiles(testlib.MachineCase):
 
         # validation
         b.click("#dropdown-menu")
-        b.click("#create-item")
+        b.click("#create-folder")
         b.assert_pixels(".pf-v5-c-modal-box", "create-modal")
         b.set_input_text("#create-directory-input", "test")
         b.set_input_text("#create-directory-input", "")

--- a/test/check-application
+++ b/test/check-application
@@ -101,6 +101,12 @@ class TestFiles(testlib.MachineCase):
         b.click("#dropdown-menu")
         b.click(f"#dropdown-menu + .pf-v5-c-menu button:contains('{action}')")
 
+    def open_folder_context_menu(self) -> None:
+        # With BiDi on Firefox a click is by default in the "middle" of the
+        # element while we want to open the current folder context and a
+        # "middle" click can be a file or folder item.
+        self.browser.mouse("#files-card-parent", "contextmenu", 1, 1)
+
     def testBasic(self) -> None:
         b = self.browser
         m = self.machine
@@ -2586,6 +2592,111 @@ class TestFiles(testlib.MachineCase):
 
         b.click(".pf-v5-c-modal-box__footer button.pf-m-secondary")
         b.wait_not_present(".file-editor-modal")
+
+    def testCreateFile(self) -> None:
+        b = self.browser
+        m = self.machine
+
+        self.enter_files()
+
+        def open_create_file_modal() -> None:
+            b.mouse("#files-card-parent", "contextmenu")
+            b.click(".contextMenu button:contains('Create file')")
+            b.wait_visible(".file-create-modal")
+            b.wait_text(".pf-v5-c-modal-box__title-text", "Create file")
+            b.wait_visible("button.pf-m-primary:disabled")
+
+        # Error cases
+        # cancel does not create a file
+        open_create_file_modal()
+        b.set_input_text("#file-name", "test.txt")
+        b.set_input_text(".file-create-modal textarea", "content")
+        b.wait_visible("button.pf-m-primary:not(:disabled)")
+        b.click(".pf-v5-c-modal-box__footer button.pf-m-link")  # cancel
+        b.wait_not_present(".pf-v5-c-modal-box")
+        m.execute("! test -f test.txt")
+
+        # file already exists
+        m.execute("runuser -u admin touch /home/admin/test.txt")
+        b.wait_visible("[data-item='test.txt']")
+        open_create_file_modal()
+        b.set_input_text("#file-name", "test.txt")
+        b.wait_text(".file-create-modal .pf-v5-c-helper-text__item-text", "File exists")
+        b.wait_visible("button.pf-m-primary:disabled")
+        b.set_input_text("#file-name", "/test.txt")
+        b.wait_text(".file-create-modal .pf-v5-c-helper-text__item-text", "Name cannot include a /")
+        b.wait_visible("button.pf-m-primary:disabled")
+
+        # Create a file as admin, we are superuser and /home owned by admin
+        b.set_input_text("#file-name", "notes.txt")
+        b.set_input_text(".file-create-modal textarea", "content")
+        b.wait_val("#create-file-owner", "admin:admin")
+        b.assert_pixels(".pf-v5-c-modal-box", "create-file-modal-superuser")
+        b.click("button.pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        self.assert_owner("/home/admin/notes.txt", "admin:admin")
+        self.assertEqual(m.execute("cat /home/admin/notes.txt"), "content")
+
+        # create a file as root.
+        open_create_file_modal()
+        b.set_input_text("#file-name", "root.txt")
+        b.set_input_text(".file-create-modal textarea", "root")
+        b.select_from_dropdown("#create-file-owner", "root:root")
+        b.click("button.pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        self.assert_owner("/home/admin/root.txt", "root:root")
+        self.assertEqual(m.execute("cat /home/admin/root.txt"), "root")
+
+        # normal user has no change owner select
+        b.drop_superuser()
+
+        open_create_file_modal()
+        b.wait_not_present("#create-file-owner")
+        b.set_input_text("#file-name", "admin.txt")
+        b.set_input_text(".file-create-modal textarea", "admin")
+        b.assert_pixels(".pf-v5-c-modal-box", "create-file-modal-admin")
+        b.click("button.pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        self.assert_owner("/home/admin/admin.txt", "admin:admin")
+        self.assertEqual(m.execute("cat /home/admin/admin.txt"), "admin")
+
+        # Escape closes the dialog
+        self.open_folder_context_menu()
+        b.click(".contextMenu button:contains('Create file')")
+        b.blur("#file-name")  # remove focus from input
+        b.key("Escape")  # Escape for modal
+        b.wait_not_present(".pf-v5-c-modal-box")
+
+        # Escape does not close the the dialog when a filename is entered
+        self.open_folder_context_menu()
+        b.click(".contextMenu button:contains('Create file')")
+        b.set_input_text("#file-name", "admin.txt")
+        b.blur("#file-name")  # remove focus from input
+        b.key("Escape")  # Escape for modal
+        b.wait_val("#file-name", "admin.txt")
+        b.click(".pf-v5-c-modal-box__footer button.pf-m-link")  # cancel
+        b.wait_not_present(".pf-v5-c-modal-box")
+
+        # Unable to create a file
+        self.open_folder_context_menu()
+        b.click(".contextMenu button:contains('Create file')")
+        b.set_input_text("#file-name", "notallowed.txt")
+        b.set_input_text(".file-create-modal textarea", "nope")
+        m.execute("chattr +i /home/admin")
+        self.addCleanup(m.execute, "chattr -i /home/admin")
+        b.click("button.pf-m-primary")
+        self.wait_modal_inline_alert("Not permitted to perform this action")
+        b.click(".pf-v5-c-modal-box__footer button.pf-m-link")  # cancel
+        b.wait_not_present(".pf-v5-c-modal-box")
+
+        # create a file as admin
+
+        # cannot create file in /home as normal user
+        b.click("li[data-location='/home'] a")
+        self.assert_last_breadcrumb("home")
+        self.open_folder_context_menu()
+        b.click(".contextMenu button:contains('Create file')")
+        b.wait_in_text("h4.pf-v5-c-alert__title", "Cannot create file in current directory")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
---

# cockpit-files: File creation support

Files can now create a new file with initial content after creation the dialog changes into editor mode so you can keep editing. When you have "administrative access" the owner of the file is pre-selected based on the owner of the directory so far /home/admin/ it is "admin:admin" and you can also change ownership to root if needed.

![image](https://github.com/user-attachments/assets/0518a768-f52c-43e7-8f84-9db779656e06)
