### PR TITLE
workflows: teach dependabot workflow to rebase

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -41,6 +41,18 @@ jobs:
               }
             }
 
+      - name: Rebase pull request and drop node_modules changes
+        run: |
+          set -x
+          git config --global user.name "GitHub Workflow"
+          git config --global user.email "cockpituous@cockpit-project.org"
+          git fetch origin main:main
+          if ! git rebase main; then
+            git reset node_modules
+            GIT_EDITOR=true git rebase --continue
+            git show --stat
+          fi
+
       - name: Update node_modules for package.json changes
         run: |
           make tools/node-modules


### PR DESCRIPTION
Our dependabot workflow is unable to deal with conflicting node_modules when we land one of the dependabot pull requests. The manual workflow before was to let dependabot re-create the pull request and then add the `node_modules` label after re-recreating the pull request. Automating this is tricky as a Github workflow cannot automate the recreate comment as it has no write permissions to our projects.

The new approach when adding a `node_modules` label will always rebase the pull request and in case of a conflict will remove the conflicting node_modules changes in the commit. Afterwards we create the new node_modules commit which can be merged.

---

Partially tested here https://github.com/jelly/cockpit-navigator/pull/11 re-adding the `node_modules` label now rebases and the new commit has no `node_modules` changes anymore.

I've kept the `set -x` as that looks nice but if Github's debug option already does that we can remove it. `git show --stat` is just a quick sanity check for myself as I don't have ssh keys / node_modules setup anymore.