### PR TITLE
package.json: Revert to sass 1.79

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,10 @@ updates:
       xterm:
         patterns:
           - "xterm*"
+    ignore:
+      # https://github.com/cockpit-project/cockpit/issues/21151
+      - dependency-name: "sass"
+      - versions: ["1.80.x", "2.x"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jed": "1.1.1",
     "language-map": "1.5.0",
     "mime-db": "1.53.0",
-    "sass": "1.80.3",
+    "sass": "1.79.6",
     "sizzle": "2.3.10",
     "stylelint": "16.3.1",
     "stylelint-config-recommended-scss": "14.0.0",


### PR DESCRIPTION
sass 1.80 (and 2.x) introduces tons of "@import rules are deprecated". These are unfixable on our side due to PatternFly using them extensively.

We don't need any new sass features, so stick to 1.79.x. Explicitly not ignore 3.x (which will drop @import) to get a reminder in the future to try and clean this up again.

Same as https://github.com/cockpit-project/cockpit/pull/21155

Fixes #799