### PR TITLE
dependabot: Keep PatternFly at current major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
     ignore:
       # https://github.com/cockpit-project/cockpit/issues/21151
       - dependency-name: "sass"
-      - versions: ["1.80.x", "2.x"]
+        versions: ["1.80.x", "2.x"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,10 @@ updates:
         patterns:
           - "xterm*"
     ignore:
+      # needs to be done in Cockpit first
+      - dependency-name: "@patternfly/*"
+        update-types: ["major"]
+
       # https://github.com/cockpit-project/cockpit/issues/21151
       - dependency-name: "sass"
         versions: ["1.80.x", "2.x"]


### PR DESCRIPTION
Major PF updates always need to be done in Cockpit first, due to all the overrides and lib.
