### PR TITLE
dependabot: Fix PatternFly update-types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
     ignore:
       # needs to be done in Cockpit first
       - dependency-name: "@patternfly/*"
-        update-types: ["major"]
+        update-types: ["version-update:semver-major"]
 
       # https://github.com/cockpit-project/cockpit/issues/21151
       - dependency-name: "sass"


### PR DESCRIPTION
Commit c5a22e1eb4 was ineffective due to `update-types` not having a correct value. See
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore

---

Fixes #807