### PR TITLE
test: remove punctuation from validation error messages

### DIFF
--- a/src/dialogs/rename.tsx
+++ b/src/dialogs/rename.tsx
@@ -38,11 +38,11 @@ const _ = cockpit.gettext;
 
 function checkName(candidate: string, entries: Record<string, FileInfo>, selectedFile: FolderFileInfo) {
     if (candidate === "") {
-        return _("Name cannot be empty.");
+        return _("Name cannot be empty");
     } else if (candidate.length >= 256) {
-        return _("Name too long.");
+        return _("Name too long");
     } else if (candidate.includes("/")) {
-        return _("Name cannot include a /.");
+        return _("Name cannot include a /");
     } else if (selectedFile.name === candidate) {
         return _("Filename is the same as original name");
     } else if (candidate in entries) {

--- a/test/check-application
+++ b/test/check-application
@@ -1050,16 +1050,16 @@ class TestFiles(testlib.MachineCase):
         b.set_input_text("#rename-item-input", "test")
         b.set_input_text("#rename-item-input", "")
         b.wait_visible("button.pf-m-primary:disabled")
-        b.wait_in_text("#rename-item-input-helper", "Name cannot be empty.")
+        b.wait_in_text("#rename-item-input-helper", "Name cannot be empty")
         b.assert_pixels(".pf-v5-c-modal-box", "rename-modal-error")
 
         b.set_input_text("#rename-item-input", "a" * 256)
         b.wait_visible("button.pf-m-primary:disabled")
-        b.wait_in_text("#rename-item-input-helper", "Name too long.")
+        b.wait_in_text("#rename-item-input-helper", "Name too long")
 
         b.set_input_text("#rename-item-input", "foo/bar")
         b.wait_visible("button.pf-m-primary:disabled")
-        b.wait_in_text("#rename-item-input-helper", "Name cannot include a /.")
+        b.wait_in_text("#rename-item-input-helper", "Name cannot include a /")
 
         b.set_input_text("#rename-item-input", "test")
         b.wait_visible("button.pf-m-primary:not(:disabled)")


### PR DESCRIPTION
This is what PatternFly advices and is consistent with the rest of our validation error messages.

---

Was brought up in the "create object PR" which needs a rebase anyway.