### PR TITLE
Remove punctuation from validation errors in create directory dialog

### DIFF
--- a/src/dialogs/mkdir.tsx
+++ b/src/dialogs/mkdir.tsx
@@ -39,11 +39,11 @@ const _ = cockpit.gettext;
 
 function check_name(candidate: string) {
     if (candidate === "") {
-        return _("Directory name cannot be empty.");
+        return _("Directory name cannot be empty");
     } else if (candidate.length >= 256) {
-        return _("Directory name too long.");
+        return _("Directory name too long");
     } else if (candidate.includes("/")) {
-        return _("Directory name cannot include a /.");
+        return _("Directory name cannot include a /");
     } else {
         return undefined;
     }

--- a/test/check-application
+++ b/test/check-application
@@ -866,15 +866,15 @@ class TestFiles(testlib.MachineCase):
         b.set_input_text("#create-directory-input", "test")
         b.set_input_text("#create-directory-input", "")
         b.wait_visible("button.pf-m-primary:disabled")
-        b.wait_in_text("#create-directory-input-helper", "Directory name cannot be empty.")
+        b.wait_in_text("#create-directory-input-helper", "Directory name cannot be empty")
 
         b.set_input_text("#create-directory-input", "a" * 256)
         b.wait_visible("button.pf-m-primary:disabled")
-        b.wait_in_text("#create-directory-input-helper", "Directory name too long.")
+        b.wait_in_text("#create-directory-input-helper", "Directory name too long")
 
         b.set_input_text("#create-directory-input", "foo/bar")
         b.wait_visible("button.pf-m-primary:disabled")
-        b.wait_in_text("#create-directory-input-helper", "Directory name cannot include a /.")
+        b.wait_in_text("#create-directory-input-helper", "Directory name cannot include a /")
 
         b.set_input_text("#create-directory-input", "test")
         b.wait_visible("button.pf-m-primary:not(:disabled)")


### PR DESCRIPTION
This is what PatternFly advices and is consistent with the rest of our validation error messages.