### PR TITLE
Support uploading files with administrator privileges

### DIFF
--- a/src/upload-button.scss
+++ b/src/upload-button.scss
@@ -79,3 +79,6 @@ button.cancel-button {
   }
 }
 
+.ct-grey-text {
+   color: var(--pf-v5-global--Color--200);
+}

--- a/test/check-application
+++ b/test/check-application
@@ -10,6 +10,7 @@ import shlex
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import List, Optional
 
 # import Cockpit's machinery for test VMs and its browser test API
 import testlib
@@ -2051,6 +2052,31 @@ class TestFiles(testlib.MachineCase):
         def dir_file_count(directory: str) -> int:
             return int(m.execute(f"find {directory} -mindepth 1 -maxdepth 1 | wc -l").strip())
 
+        def assert_upload_alert(files: List[str], owner_group: Optional[str] = None, *,
+                                close: bool = True, pixel_test: bool = False) -> None:
+            title = ""
+            description = ""
+            if len(files) > 1:
+                title = "Files uploaded"
+                description = f"{len(files)} files"
+            else:
+                title = "File uploaded"
+                description = files[0]
+
+            if owner_group:
+                # Default umask should be 022
+                description += f"Uploaded as {owner_group}, rw- r-- r--"
+
+            b.wait_in_text(".pf-v5-c-alert__title", title)
+            b.wait_text(".pf-v5-c-alert__description", description)
+
+            if pixel_test:
+                b.assert_pixels(".pf-v5-c-alert.pf-m-success", "multiple-upload-alert-success")
+
+            if close:
+                b.click(".pf-v5-c-alert__action button")
+                b.wait_not_present(".pf-v5-c-alert__action")
+
         with tempfile.TemporaryDirectory() as tmpdir:
             # Test cancelling of upload
             big_file = str(Path(tmpdir) / "bigfile.img")
@@ -2129,9 +2155,7 @@ class TestFiles(testlib.MachineCase):
             with b.wait_timeout(30):
                 b.wait(lambda: int(m.execute(f"ls {dest_dir} | wc -l").strip()) == len(files))
 
-            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
-            b.click(".pf-v5-c-alert__action button")
-            b.wait_not_present(".pf-v5-c-alert__action")
+            assert_upload_alert(files, "admin:admin", pixel_test=True)
 
             # Verify ownership
             filename = os.path.basename(files[0])
@@ -2164,10 +2188,7 @@ class TestFiles(testlib.MachineCase):
             b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Replace file {filename}?")
             b.click("button.pf-m-warning:contains('Replace')")
             b.wait_not_present(".pf-v5-c-modal-box")
-
-            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
-            b.click(".pf-v5-c-alert__action button")
-            b.wait_not_present(".pf-v5-c-alert__action")
+            assert_upload_alert([os.path.basename(files[0])], "admin:admin")
 
             self.assertEqual(m.execute(f"cat {dest_dir}/{filename}"),
                             subprocess.check_output(["cat", files[0]]).decode())
@@ -2211,10 +2232,7 @@ class TestFiles(testlib.MachineCase):
             b.click("button.pf-m-warning:contains('Replace')")
             b.wait_not_present(".pf-v5-c-modal-box")
 
-            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
-            b.click(".pf-v5-c-alert__action button")
-            b.wait_not_present(".pf-v5-c-alert__action")
-
+            assert_upload_alert(files, "admin:admin")
             verify_uploaded_files(changed=True)
 
             # Upload one file new file which is uploaded automatically
@@ -2235,7 +2253,9 @@ class TestFiles(testlib.MachineCase):
                     b.click("button.pf-m-secondary:contains('Keep original')")
 
             b.wait_not_present(".pf-v5-c-modal-box")
-            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
+            b.wait_in_text(".pf-v5-c-alert__title", "File uploaded")
+            b.wait_in_text(".pf-v5-c-alert__description", "newfile.txt")
+            b.wait_in_text(".pf-v5-c-alert__description", "Uploaded as admin:admin")
             b.click(".pf-v5-c-alert__action button")
             b.wait_not_present(".pf-v5-c-alert__action")
 
@@ -2259,11 +2279,58 @@ class TestFiles(testlib.MachineCase):
                     b.click("button.pf-m-secondary:contains('Keep original')")
 
             b.wait_not_present(".pf-v5-c-modal-box")
-            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
-            b.click(".pf-v5-c-alert__action button")
-            b.wait_not_present(".pf-v5-c-alert__action")
+            assert_upload_alert([os.path.basename(files[-1])], "admin:admin")
 
             self.assertEqual(m.execute(f"cat {dest_dir}/{filename}"), "new content")
+
+            # As administrator upload in testuser and change ownership to root:root
+
+            m.execute("useradd --create-home testuser")
+            b.go('/files#/?path=/home/testuser')
+            b.wait_not_present('.pf-v5-c-empty-state')
+
+            testuser_file = str(Path(tmpdir) / "testuser.txt")
+            test_content = "testdata"
+            with open(testuser_file, "w") as fp:
+                fp.write(test_content)
+
+            testuser_filename = os.path.basename(testuser_file)
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", [testuser_file])
+            assert_upload_alert([testuser_filename], "testuser:testuser", close=False)
+            self.assert_owner(f'/home/testuser/{testuser_filename}', 'testuser:testuser')
+            contents = m.execute(f"cat /home/testuser/{testuser_filename}")
+            self.assertEqual(contents, test_content)
+
+            b.click(".pf-v5-c-alert__action-group button")
+            b.wait_not_present(".pf-v5-c-alert__action")
+            b.wait_in_text(".pf-v5-c-modal-box__title-text", testuser_filename)
+            b.wait_val("#edit-permissions-owner", "testuser")
+            b.wait_val("#edit-permissions-group", "testuser")
+            b.wait_val("#edit-permissions-owner-access", "read-write")
+            b.wait_val("#edit-permissions-group-access", "read-only")
+            b.wait_val("#edit-permissions-other-access", "read-only")
+
+            b.select_from_dropdown("#edit-permissions-owner", "root")
+            b.select_from_dropdown("#edit-permissions-group", "root")
+            b.click("button.pf-m-primary")
+            b.wait_not_present(".pf-v5-c-modal-box")
+
+            self.assert_owner(f'/home/testuser/{testuser_filename}', 'root:root')
+
+            # Uploading to an immutable dir fails to create a temp file, check that it is cleaned up
+
+            m.execute("chattr +i /home/testuser")
+            self.addCleanup(m.execute, "chattr -i /home/testuser")
+            b.click("#upload-file-btn")
+            b.upload_files("#upload-file-btn + input[type='file']", [files[-1]])
+
+            b.go(f'/files#/?path={dest_dir}')
+            b.wait_not_present('.pf-v5-c-empty-state')
+            b.wait_in_text(".pf-v5-c-alert__title", "Failed")
+            b.wait_in_text(".pf-v5-c-alert__description", "Not permitted to perform this action")
+            b.click(".pf-v5-c-alert__action button")
+            b.wait_not_present(".pf-v5-c-alert__action")
 
             # Non-admin session
             b.drop_superuser()
@@ -2275,7 +2342,7 @@ class TestFiles(testlib.MachineCase):
             b.click("#upload-file-btn")
             b.upload_files("#upload-file-btn + input[type='file']", [files[-1]])
 
-            b.wait_in_text(".pf-v5-c-alert__description", "Successfully uploaded file")
+            b.wait_in_text(".pf-v5-c-alert__title", "File uploaded")
             b.click(".pf-v5-c-alert__action button")
             b.wait_not_present(".pf-v5-c-alert__action")
 


### PR DESCRIPTION
Files could not yet support uploading to non-logged in user directories as these files would always be uploaded as `root:root` and this might not be wanted in directories not owned by `root`.

---

# Allow uploading files as administrator

Cockpit-files now allows you to upload files into directories not owned by the logged in user, when you are administrator. It will by default upload the file with the same user/group as the current directory. You can change the ownership after uploading.

![image](https://github.com/user-attachments/assets/b39e8179-13d1-4e72-977b-7975e781bac6)
