### PR TITLE
test: Move reference-image to Fedora 41

### DIFF
--- a/test/reference-image
+++ b/test/reference-image
@@ -1,1 +1,1 @@
-fedora-40
+fedora-41


### PR DESCRIPTION
Adjust the mobile icon list pixel ref for the disabled host switcher on Fedora 41.