### PR TITLE
Allow editing multiple file permissions

### DIFF
--- a/src/dialogs/permissions.css
+++ b/src/dialogs/permissions.css
@@ -1,0 +1,3 @@
+.multiple-files-expandable {
+     margin-block-start: var(--pf-v5-global--spacer--md);
+}

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -80,8 +80,7 @@ export function get_menu_items(
     const supportsTerminal = cockpit.manifests.system?.tools?.terminal?.capabilities?.includes("path");
 
     if (selected.length === 0) {
-        // HACK: basename('/') is currently ""
-        const current_directory = { ...cwdInfo, name: basename(path) || "/", category: null, to: null };
+        const current_directory = { ...cwdInfo, name: basename(path), category: null, to: null };
         const base_path = get_base_path(path);
         menuItems.push(
             {
@@ -105,7 +104,7 @@ export function get_menu_items(
             {
                 id: "edit-permissions",
                 title: _("Edit permissions"),
-                onClick: () => edit_permissions(dialogs, current_directory, base_path)
+                onClick: () => edit_permissions(dialogs, [current_directory], base_path)
             }
         );
         if (supportsTerminal) {
@@ -145,7 +144,7 @@ export function get_menu_items(
             {
                 id: "edit-permissions",
                 title: _("Edit permissions"),
-                onClick: () => edit_permissions(dialogs, item, path)
+                onClick: () => edit_permissions(dialogs, [item], path)
             },
             {
                 id: "rename-item",
@@ -193,6 +192,20 @@ export function get_menu_items(
                 onClick: () => confirm_delete(dialogs, path, selected, setSelected)
             }
         );
+
+        // Don't allow mixing regular files and folders when editing multiple
+        // permissions, it can be unclear if we are changing the folders
+        // permissions or the permissions of the files underneath.
+        if (selected.every(sel => sel.type === "reg")) {
+            menuItems.push(
+                { type: "divider" },
+                {
+                    id: "edit-permissions",
+                    title: _("Edit permissions"),
+                    onClick: () => edit_permissions(dialogs, selected, path)
+                }
+            );
+        }
     }
 
     return menuItems;

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -23,7 +23,7 @@ import { AlertVariant } from "@patternfly/react-core/dist/esm/components/Alert";
 
 import cockpit from "cockpit";
 import type { FileInfo } from "cockpit/fsinfo";
-import { basename } from "cockpit-path";
+import { basename, dirname } from "cockpit-path";
 import type { Dialogs } from 'dialogs';
 
 import type { FolderFileInfo } from "./app";
@@ -80,6 +80,9 @@ export function get_menu_items(
     const supportsTerminal = cockpit.manifests.system?.tools?.terminal?.capabilities?.includes("path");
 
     if (selected.length === 0) {
+        // HACK: basename('/') is currently ""
+        const current_directory = { ...cwdInfo, name: basename(path) || "/", category: null, to: null };
+        const base_path = get_base_path(path);
         menuItems.push(
             {
                 id: "paste-item",
@@ -102,7 +105,7 @@ export function get_menu_items(
             {
                 id: "edit-permissions",
                 title: _("Edit permissions"),
-                onClick: () => edit_permissions(dialogs, null, path)
+                onClick: () => edit_permissions(dialogs, current_directory, base_path)
             }
         );
         if (supportsTerminal) {
@@ -193,4 +196,17 @@ export function get_menu_items(
     }
 
     return menuItems;
+}
+
+// Get the dirname based on the given path with special logic for "/", so we don't show the root directory as "//"
+// As selected.name would already be "/".
+function get_base_path(path: string) {
+    let base_path = dirname(path);
+    if (base_path === "/")
+        base_path = "";
+    else {
+        base_path += "/";
+    }
+
+    return base_path;
 }

--- a/test/check-application
+++ b/test/check-application
@@ -1569,6 +1569,93 @@ class TestFiles(testlib.MachineCase):
         b.click("li[data-location='/home/admin'] a")
         self.assert_last_breadcrumb("admin")
 
+        # Edit multiple files
+        create_multiple_dirs_sh = "mkdir -p /home/admin/multiple/testdir\n"
+        for i in range(20):
+            create_multiple_dirs_sh += f"touch /home/admin/multiple/filename{i}\n"
+
+        self.write_file(f"{self.vm_tmpdir}/create-multiple-dirs.sh", create_multiple_dirs_sh, perm="755")
+        m.execute(f"runuser -u admin {self.vm_tmpdir}/create-multiple-dirs.sh")
+        b.mouse("[data-item='multiple']", "dblclick")
+        b.wait_not_present(".pf-v5-c-empty-state")
+        self.assert_last_breadcrumb("multiple")
+
+        # Editing two files
+        b.click("[data-item='filename1']")
+        b.mouse("[data-item='filename2']", "click", ctrlKey=True)
+        b.mouse("[data-item='filename1']", "contextmenu")
+        b.click("button:contains('Edit permissions')")
+
+        b.wait_text(".pf-v5-c-modal-box__title-text", "Permissions for 2 files")
+        b.wait_in_text("#edit-permissions-owner", "admin")
+        b.wait_in_text("#edit-permissions-group", "admin")
+        b.select_from_dropdown("#edit-permissions-owner-access", "read-only")
+        b.select_from_dropdown("#edit-permissions-group-access", "no-access")
+        b.select_from_dropdown("#edit-permissions-other-access", "no-access")
+        b.click(".pf-v5-c-modal-box button.pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        self.assertEqual(self.stat("%A", "/home/admin/multiple/filename1"), "-r--------")
+        self.assertEqual(self.stat("%A", "/home/admin/multiple/filename2"), "-r--------")
+
+        # No owner/group shown if ownership differs
+        def verify_no_owner_group_shown() -> None:
+            # HACK: the selected state contains a copy of files state so permissions information is not updated.
+            b.mouse("[data-item='filename1']", "click", ctrlKey=True)
+            b.mouse("[data-item='filename1']", "click", ctrlKey=True)
+            b.mouse("[data-item='filename1']", "contextmenu")
+            b.click("button:contains('Edit permissions')")
+
+            b.wait_visible("#edit-permissions-owner-access")
+            b.wait_not_present("#edit-permissions-owner")
+            b.wait_not_present("#edit-permissions-group")
+            b.select_from_dropdown("#edit-permissions-owner-access", "read-write")
+            b.select_from_dropdown("#edit-permissions-group-access", "read-only")
+            b.select_from_dropdown("#edit-permissions-other-access", "read-only")
+
+            b.click(".pf-v5-c-modal-box button.pf-m-primary")
+            b.wait_not_present(".pf-v5-c-modal-box")
+
+            self.assertEqual(self.stat("%A", "/home/admin/multiple/filename1"), "-rw-r--r--")
+            self.assertEqual(self.stat("%A", "/home/admin/multiple/filename2"), "-rw-r--r--")
+
+        m.execute("chmod 600 /home/admin/multiple/filename1")
+        m.execute("chown root: /home/admin/multiple/filename1")
+        b.wait_in_text("[data-item='filename1'] .item-owner", "root")
+        verify_no_owner_group_shown()
+
+        m.execute("chown admin:root /home/admin/multiple/filename1")
+        b.wait_in_text("[data-item='filename1'] .item-owner", "admin:root")
+        verify_no_owner_group_shown()
+
+        # No Edit permissions when selecting a folder and files
+        b.mouse("[data-item='testdir']", "click", ctrlKey=True)
+        b.mouse("[data-item='filename1']", "contextmenu")
+        b.wait_visible("button:contains('Delete')")
+        b.wait_not_present("button:contains('Edit permissions')")
+
+        # Editing > 10 files, select only files with the same owner/group
+        # Test that we see an expander and can toggle it.
+        b.mouse("[data-item='testdir']", "click", ctrlKey=True)
+        b.mouse("[data-item='filename1']", "click", ctrlKey=True)
+        for i in range(3, 15):
+            b.mouse(f"[data-item='filename{i}']", "click", ctrlKey=True)
+
+        b.mouse("[data-item='filename3']", "contextmenu")
+        b.click("button:contains('Edit permissions')")
+
+        b.wait_text(".pf-v5-c-modal-box__title-text", "Permissions for 13 files")
+        b.assert_pixels(".pf-v5-c-modal-box", "multiple-files-permissions-modal")
+        # Expand files
+        b.wait_text(".pf-v5-c-expandable-section button", "Show all files")
+        b.click(".pf-v5-c-expandable-section button")
+        b.wait_text(".pf-v5-c-expandable-section button", "Collapse")
+        b.click(".pf-v5-c-modal-box button.pf-m-link")
+        b.wait_not_present(".pf-v5-c-modal-box")
+
+        b.go("/files#/?path=/home/admin")
+        self.assert_last_breadcrumb("admin")
+        b.wait_not_present(".pf-v5-c-empty-state")
+
         # As normal user you cannot change user/group permissions
         b.drop_superuser()
 


### PR DESCRIPTION
Blocked:

* [x] https://github.com/cockpit-project/cockpit-files/pull/849

As discussed on Thursday, for multiple file uploads we want to allow users to change multiple file(s) permissions to be changed. This has been implemented with the following restrictions:

* Only multiple files can be edited, not block devices, fifo's, directories etc.
* Don't show SELinux context as it makes no sense for multiple files
* Don't allow changing of the owner/group if they don't match between files (so not to have inconsistency)

---

# Allow editing of multiple file permissions

The permissions of multiple selected files can now be changed.

![image](https://github.com/user-attachments/assets/c520890e-4c85-4445-bed1-ae539e5dc5a9)

![image](https://github.com/user-attachments/assets/98c9e33e-e24d-4d79-9492-76b6a277157b)
