### PR TITLE
dependabot: Don't update major React version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,10 @@ updates:
       - dependency-name: "@patternfly/*"
         update-types: ["version-update:semver-major"]
 
+      # PF5 requires fixed major React version
+      - dependency-name: "*react*"
+        update-types: ["version-update:semver-major"]
+
       # https://github.com/cockpit-project/cockpit/issues/21151
       - dependency-name: "sass"
         versions: ["1.80.x", "2.x"]


### PR DESCRIPTION
PatternFly 5 has a React 18 peer dependency, so they need to be updated together.

Closes #864