### PR TITLE
test: Add ws-container scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,21 +169,10 @@ rpm: $(TARFILE) $(NODE_CACHE) $(SPEC)
 	rm -r "`pwd`/rpmbuild"
 	rm -r "`pwd`/output" "`pwd`/build"
 
-ifeq ("$(TEST_SCENARIO)","pybridge")
-COCKPIT_PYBRIDGE_REF = main
-COCKPIT_WHEEL = cockpit-0-py3-none-any.whl
-
-$(COCKPIT_WHEEL):
-	pip wheel git+https://github.com/cockpit-project/cockpit.git@${COCKPIT_PYBRIDGE_REF}
-
-VM_DEPENDS = $(COCKPIT_WHEEL)
-VM_CUSTOMIZE_FLAGS = --install $(COCKPIT_WHEEL)
-endif
-
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed
 $(VM_IMAGE): export XZ_OPT=-0
-$(VM_IMAGE): $(TARFILE) $(NODE_CACHE) packaging/arch/PKGBUILD bots test/vm.install $(VM_DEPENDS)
+$(VM_IMAGE): $(TARFILE) $(NODE_CACHE) packaging/arch/PKGBUILD bots test/vm.install
 	bots/image-customize --no-network --fresh \
 		$(VM_CUSTOMIZE_FLAGS) \
 		--upload $(NODE_CACHE):/var/tmp/ --build $(TARFILE) \

--- a/Makefile
+++ b/Makefile
@@ -169,14 +169,17 @@ rpm: $(TARFILE) $(NODE_CACHE) $(SPEC)
 	rm -r "`pwd`/rpmbuild"
 	rm -r "`pwd`/output" "`pwd`/build"
 
+ifeq ("$(TEST_SCENARIO)","ws-container")
+VM_INSTALL = --upload $(TARFILE):/var/tmp/ --script $(CURDIR)/test/vm-ws.install
+else
+VM_INSTALL = --upload $(NODE_CACHE):/var/tmp/ --build $(TARFILE) --script $(CURDIR)/test/vm.install
+endif
+
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed
 $(VM_IMAGE): export XZ_OPT=-0
-$(VM_IMAGE): $(TARFILE) $(NODE_CACHE) packaging/arch/PKGBUILD bots test/vm.install
-	bots/image-customize --no-network --fresh \
-		$(VM_CUSTOMIZE_FLAGS) \
-		--upload $(NODE_CACHE):/var/tmp/ --build $(TARFILE) \
-		--script $(CURDIR)/test/vm.install $(TEST_OS)
+$(VM_IMAGE): $(TARFILE) $(NODE_CACHE) packaging/arch/PKGBUILD bots test/vm.install test/vm-ws.install
+	bots/image-customize --no-network --fresh $(VM_CUSTOMIZE_FLAGS) $(VM_INSTALL) $(TEST_OS)
 
 # convenience target for the above
 vm: $(VM_IMAGE)

--- a/test/check-application
+++ b/test/check-application
@@ -1022,7 +1022,7 @@ class TestFiles(testlib.MachineCase):
         b.click("button.pf-m-primary")
         b.wait_in_text("[data-item='newdir1'] .item-owner", "testuser")
 
-        if self.system_before(329):
+        if not m.ws_container and self.system_before(329):
             # Open in terminal feature not supported before cockpit 329
             b.mouse("[data-item='newdir1']", "contextmenu")
             b.wait_visible(".contextMenu button:contains('Delete')")

--- a/test/check-application
+++ b/test/check-application
@@ -1951,7 +1951,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_visible("[data-item='file0'].row-selected")
 
         # Test with very long hostnames
-        original_hostname = m.execute('hostnamectl hostname').strip()
+        original_hostname = m.execute('hostname').strip()
         self.addCleanup(m.execute, ['hostnamectl', 'set-hostname', original_hostname])
         # length of testing farm hostname
         m.execute('hostnamectl set-hostname aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee.testing-farm')

--- a/test/vm-ws.install
+++ b/test/vm-ws.install
@@ -1,0 +1,24 @@
+#!/bin/sh
+# image-customize script to prepare a bots VM for testing this application
+# in TEST_SCENARIO=ws-container.
+set -eux
+
+# back up original ws image
+podman tag quay.io/cockpit/ws:latest localhost/ws:released
+
+# update ws container with our current code
+cd /var/tmp
+tar --strip-components=1 -xvf cockpit-files*.tar.* cockpit-files/dist
+
+podman build -f - -t quay.io/cockpit/ws:latest . <<EOF
+FROM quay.io/cockpit/ws
+RUN rm -rf /usr/share/cockpit/files
+COPY dist /usr/share/cockpit/files
+EOF
+
+# remove preinstalled rpms
+dnf -C remove -y cockpit-bridge cockpit-ws
+
+if systemctl is-active -q firewalld.service; then
+    firewall-cmd --add-service=cockpit --permanent
+fi


### PR DESCRIPTION
cockpit-files currently works fine on RHEL 8 with beibooting. Let's keep
it that way: Add a rhel-8.10/ws-container scenario that runs the tests
through our ws container.

Fixes #914

---

 - [x] https://github.com/cockpit-project/bots/pull/7355
 - [x] https://github.com/cockpit-project/bots/pull/7356
 - [x] change test preparation to `--no-network`
 - [x] fix [failing tests](https://cockpit-logs.us-east-1.linodeobjects.com/pull-917-9b03e008-20250127-222008-rhel-8-10-ws-container/log.html)
 - [x] #918
 - [x] #919