### PR TITLE
test: Fix empty dir check in testPermissions

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1385,9 +1385,9 @@ class TestFiles(testlib.MachineCase):
         # Test changing CWD permissions
         test_dir = "/home/admin/testdir"
         m.execute(['runuser', '-u', 'admin', 'mkdir', test_dir])
-        b.wait_visible("[data-item='testdir']")
         b.mouse("[data-item='testdir']", "dblclick")
-        b.wait_not_present(".pf-v5-c-empty-state")
+        b.wait_visible(".pf-v5-c-empty-state")
+        self.assert_last_breadcrumb("testdir")
 
         # Via contextmenu
         b.mouse("#files-card-parent", "contextmenu")


### PR DESCRIPTION
When opening an empty dir, we expect the "Directory is empty" empty state to *appear*. Checking for its absence is a race condition. Additionally verify that the breadcrumb shows the expected directory.

Drop the redundant wait_visible() before the click.

---

I ran into this in #917 all the time, and it's also very prominent on the [weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit-files&days=7):

![image](https://github.com/user-attachments/assets/64990fbd-3e70-45e5-8a10-22ae387e7521)
