### PR TITLE
test: Fix empty dir check in testUpload

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -2318,7 +2318,7 @@ class TestFiles(testlib.MachineCase):
 
             m.execute("useradd --create-home testuser")
             b.go('/files#/?path=/home/testuser')
-            b.wait_not_present('.pf-v5-c-empty-state')
+            b.wait_visible('.pf-v5-c-empty-state')
 
             testuser_file = str(Path(tmpdir) / "testuser.txt")
             test_content = "testdata"


### PR DESCRIPTION
Similar to commit b045f17402, this test changes into an empty (except for 3 hidden files) directory. So wait for that. This fixes a race condition where the test would only succeed if the empty state wasn't rendered too fast.

---

[failure 1](https://cockpit-logs.us-east-1.linodeobjects.com/pull-917-9928627b-20250128-090420-fedora-41/log.html#19-2), [failure 2](https://cockpit-logs.us-east-1.linodeobjects.com/pull-917-9928627b-20250128-080848-fedora-41/log.html#19-1)

Spotted in #917 due to 3x affected tests.