### PR TITLE
Fix imports and add missing license

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -17,11 +17,12 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import {
-    AlertGroup, Alert, AlertVariant, AlertActionCloseButton
+    AlertGroup, Alert, AlertActionCloseButton
 } from "@patternfly/react-core/dist/esm/components/Alert";
+import type { AlertVariant } from "@patternfly/react-core/dist/esm/components/Alert";
 import { Card } from "@patternfly/react-core/dist/esm/components/Card";
 import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page";
 import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack";
@@ -34,6 +35,8 @@ import { WithDialogs } from "dialogs";
 import { useInit, usePageLocation } from "hooks";
 import { superuser } from "superuser";
 
+import { FilesContext, usePath } from "./common.ts";
+import type { FolderFileInfo } from "./common.ts";
 import { FilesBreadcrumbs } from "./files-breadcrumbs.tsx";
 import { FilesFolderView } from "./files-folder-view.tsx";
 import { FilesFooterDetail } from "./files-footer-detail.tsx";
@@ -49,46 +52,6 @@ interface Alert {
     detail?: string | React.ReactNode,
     actionLinks?: React.ReactNode
 }
-
-export interface FolderFileInfo extends FileInfo {
-    name: string,
-    to: string | null,
-    category: { class: string } | null,
-}
-
-interface FilesContextType {
-    addAlert: (title: string, variant: AlertVariant, key: string, detail?: string | React.ReactNode,
-               actionLinks?: React.ReactNode) => void,
-    removeAlert: (key: string) => void,
-    cwdInfo: FileInfo | null,
-}
-
-export const FilesContext = React.createContext({
-    addAlert: () => console.warn("FilesContext not initialized"),
-    removeAlert: () => console.warn("FilesContext not initialized"),
-    cwdInfo: null,
-} as FilesContextType);
-
-export const useFilesContext = () => useContext(FilesContext);
-
-export const usePath = () => {
-    const { options } = usePageLocation();
-    let currentPath = decodeURIComponent(options.path?.toString() || "/");
-
-    // Trim all trailing slashes
-    currentPath = currentPath.replace(/\/+$/, '');
-
-    // Our path will always be `/foo/` formatted
-    if (!currentPath.endsWith("/")) {
-        currentPath += "/";
-    }
-
-    if (!currentPath.startsWith("/")) {
-        currentPath = `/${currentPath}`;
-    }
-
-    return currentPath;
-};
 
 export const Application = () => {
     const { options } = usePageLocation();

--- a/src/common.ts
+++ b/src/common.ts
@@ -17,12 +17,55 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import cockpit from "cockpit";
-import { FileInfo } from "cockpit/fsinfo.ts";
+import React, { useContext } from "react";
 
-import { FolderFileInfo } from "./app.ts";
+import type { AlertVariant } from "@patternfly/react-core/dist/esm/components/Alert";
+
+import cockpit from "cockpit";
+import type { FileInfo } from "cockpit/fsinfo.ts";
+import { usePageLocation } from "hooks";
 
 const _ = cockpit.gettext;
+
+export interface FolderFileInfo extends FileInfo {
+    name: string,
+    to: string | null,
+    category: { class: string } | null,
+}
+
+interface FilesContextType {
+    addAlert: (title: string, variant: AlertVariant, key: string, detail?: string | React.ReactNode,
+               actionLinks?: React.ReactNode) => void,
+    removeAlert: (key: string) => void,
+    cwdInfo: FileInfo | null,
+}
+
+export const FilesContext = React.createContext({
+    addAlert: () => console.warn("FilesContext not initialized"),
+    removeAlert: () => console.warn("FilesContext not initialized"),
+    cwdInfo: null,
+} as FilesContextType);
+
+export const useFilesContext = () => useContext(FilesContext);
+
+export const usePath = () => {
+    const { options } = usePageLocation();
+    let currentPath = decodeURIComponent(options.path?.toString() || "/");
+
+    // Trim all trailing slashes
+    currentPath = currentPath.replace(/\/+$/, '');
+
+    // Our path will always be `/foo/` formatted
+    if (!currentPath.endsWith("/")) {
+        currentPath += "/";
+    }
+
+    if (!currentPath.startsWith("/")) {
+        currentPath = `/${currentPath}`;
+    }
+
+    return currentPath;
+};
 
 export const permissions = [
     /* 0 */ _("None"),

--- a/src/dialogs/create-file.tsx
+++ b/src/dialogs/create-file.tsx
@@ -35,8 +35,7 @@ import { useInit } from 'hooks';
 import { superuser } from 'superuser';
 
 import "./editor.scss";
-import { useFilesContext } from '../app.tsx';
-import { checkFilename } from '../common.ts';
+import { checkFilename, useFilesContext } from '../common.ts';
 import { get_owner_candidates } from '../ownership.tsx';
 
 const _ = cockpit.gettext;

--- a/src/dialogs/delete.tsx
+++ b/src/dialogs/delete.tsx
@@ -27,7 +27,7 @@ import { InlineNotification } from 'cockpit-components-inline-notification';
 import type { Dialogs, DialogResult } from 'dialogs';
 import { fmt_to_fragments } from 'utils';
 
-import type { FolderFileInfo } from '../app';
+import type { FolderFileInfo } from '../common.ts';
 
 const _ = cockpit.gettext;
 

--- a/src/dialogs/keyboardShortcutsHelp.tsx
+++ b/src/dialogs/keyboardShortcutsHelp.tsx
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import React from 'react';
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";

--- a/src/dialogs/mkdir.tsx
+++ b/src/dialogs/mkdir.tsx
@@ -32,7 +32,7 @@ import { InlineNotification } from 'cockpit-components-inline-notification';
 import type { Dialogs, DialogResult } from 'dialogs';
 import { superuser } from 'superuser';
 
-import { useFilesContext } from '../app.tsx';
+import { useFilesContext } from '../common.ts';
 import { get_owner_candidates } from '../ownership.tsx';
 
 const _ = cockpit.gettext;

--- a/src/dialogs/permissions.tsx
+++ b/src/dialogs/permissions.tsx
@@ -40,8 +40,8 @@ import * as python from "python";
 import { superuser } from 'superuser';
 import { fmt_to_fragments } from 'utils.tsx';
 
-import type { FolderFileInfo } from '../app.tsx';
 import { inode_types } from '../common.ts';
+import type { FolderFileInfo } from '../common.ts';
 
 // Following python file is loaded as a string (esbuild loader: text)
 // @ts-expect-error Cannot find module or its corresponding type declaration

--- a/src/dialogs/rename.tsx
+++ b/src/dialogs/rename.tsx
@@ -32,8 +32,8 @@ import { InlineNotification } from 'cockpit-components-inline-notification';
 import type { Dialogs, DialogResult } from 'dialogs';
 import { fmt_to_fragments } from 'utils';
 
-import { FolderFileInfo, useFilesContext } from '../app.tsx';
-import { checkFilename } from '../common.ts';
+import { checkFilename, useFilesContext } from '../common.ts';
+import type { FolderFileInfo } from '../common.ts';
 
 const _ = cockpit.gettext;
 

--- a/src/download.tsx
+++ b/src/download.tsx
@@ -19,7 +19,7 @@
 
 import cockpit from 'cockpit';
 
-import type { FolderFileInfo } from './app.ts';
+import type { FolderFileInfo } from './common.ts';
 
 export function downloadFile(currentPath: string, selected: FolderFileInfo) {
     const payload = JSON.stringify({

--- a/src/files-breadcrumbs.tsx
+++ b/src/files-breadcrumbs.tsx
@@ -33,7 +33,7 @@ import cockpit from "cockpit";
 import { basename } from "cockpit-path";
 import { useInit } from "hooks";
 
-import { useFilesContext } from "./app.tsx";
+import { useFilesContext } from "./common.ts";
 
 const _ = cockpit.gettext;
 

--- a/src/files-card-body.tsx
+++ b/src/files-card-body.tsx
@@ -35,8 +35,8 @@ import { dirname } from "cockpit-path.ts";
 import { useDialogs } from "dialogs";
 import * as timeformat from "timeformat";
 
-import { FolderFileInfo, useFilesContext } from "./app.tsx";
-import { get_permissions, permissionShortStr } from "./common.ts";
+import { get_permissions, permissionShortStr, useFilesContext } from "./common.ts";
+import type { FolderFileInfo } from "./common.ts";
 import { confirm_delete } from "./dialogs/delete.tsx";
 import { show_create_directory_dialog } from "./dialogs/mkdir.tsx";
 import { show_rename_dialog } from "./dialogs/rename.tsx";

--- a/src/files-folder-view.tsx
+++ b/src/files-folder-view.tsx
@@ -26,7 +26,7 @@ import { debounce } from "throttle-debounce";
 import cockpit from "cockpit";
 import { EmptyStatePanel } from "cockpit-components-empty-state";
 
-import type { FolderFileInfo } from "./app.tsx";
+import type { FolderFileInfo } from "./common.ts";
 import { FilesCardBody } from "./files-card-body.tsx";
 import { as_sort, FilesCardHeader } from "./header.tsx";
 

--- a/src/files-footer-detail.tsx
+++ b/src/files-footer-detail.tsx
@@ -12,9 +12,8 @@ import cockpit from "cockpit";
 import type { FileInfo } from "cockpit/fsinfo.ts";
 import * as timeformat from "timeformat";
 
-import { useFilesContext } from './app.tsx';
-import type { FolderFileInfo } from "./app.tsx";
-import { get_permissions, permissionShortStr } from "./common.ts";
+import { get_permissions, permissionShortStr, useFilesContext } from "./common.ts";
+import type { FolderFileInfo } from "./common.ts";
 
 const _ = cockpit.gettext;
 

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -32,7 +32,8 @@ import cockpit from "cockpit";
 import { KebabDropdown } from "cockpit-components-dropdown";
 import { useDialogs } from "dialogs";
 
-import { FolderFileInfo, useFilesContext } from "./app.tsx";
+import { useFilesContext } from "./common.ts";
+import type { FolderFileInfo } from "./common.ts";
 import { showKeyboardShortcuts } from "./dialogs/keyboardShortcutsHelp.tsx";
 import { get_menu_items } from "./menu.tsx";
 import { UploadButton } from "./upload-button.tsx";

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -26,7 +26,7 @@ import type { FileInfo } from "cockpit/fsinfo";
 import { basename, dirname } from "cockpit-path";
 import type { Dialogs } from 'dialogs';
 
-import type { FolderFileInfo } from "./app";
+import type { FolderFileInfo } from "./common.ts";
 import { show_create_file_dialog } from './dialogs/create-file.tsx';
 import { confirm_delete } from './dialogs/delete.tsx';
 import { edit_file, MAX_EDITOR_FILE_SIZE } from './dialogs/editor.tsx';

--- a/src/upload-button.tsx
+++ b/src/upload-button.tsx
@@ -37,8 +37,8 @@ import { superuser } from "superuser";
 import * as timeformat from "timeformat";
 import { fmt_to_fragments } from "utils";
 
-import { FolderFileInfo, useFilesContext } from "./app.tsx";
-import { permissionShortStr } from "./common.ts";
+import { permissionShortStr, useFilesContext } from "./common.ts";
+import type { FolderFileInfo } from "./common.ts";
 import { edit_permissions } from "./dialogs/permissions.tsx";
 import { UploadContext } from "./files-folder-view.tsx";
 import { get_owner_candidates } from "./ownership.tsx";


### PR DESCRIPTION
Fix imports to avoid importing from `app.tsx` and use `import type` where possible.
Add missing license to keyboardShortcutsHelp.tsx