### PR TITLE
Replace cockpit-navigator with cockpit-files

### DIFF
--- a/packaging/cockpit-files.spec.in
+++ b/packaging/cockpit-files.spec.in
@@ -19,6 +19,9 @@ BuildRequires: gettext
 
 Requires: cockpit-bridge >= 318
 
+# Replace the older cockpit-navigator provided by 45Drives
+Obsoletes: cockpit-navigator < 0.5.11
+
 %{NPM_PROVIDES}
 
 %description


### PR DESCRIPTION
Now that https://fedoraproject.org/wiki/Changes/Replace_Cockpit_Navigator_With_Cockpit_Files is approved, let's get this into Fedora.