### PR TITLE
packit: Drop copr_build job redundancy, re-disable Fedora 42

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -23,13 +23,8 @@ actions:
 jobs:
   - job: copr_build
     trigger: pull_request
-    targets:
-      - fedora-41
-      - fedora-42
-      - fedora-development
-      - fedora-latest-stable-aarch64
-      - centos-stream-9-x86_64
-      - centos-stream-10
+    # implicitly defined by "tests" job, no extra build-only targets
+    targets: []
 
   - job: tests
     trigger: pull_request

--- a/packit.yaml
+++ b/packit.yaml
@@ -30,8 +30,9 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-41
-      - fedora-42
-      - fedora-development
+      # https://pagure.io/fedora-infrastructure/issue/12389
+      # - fedora-42
+      - fedora-rawhide
       - fedora-latest-stable-aarch64
       - centos-stream-9-x86_64
       - centos-stream-10


### PR DESCRIPTION
Similar to https://github.com/cockpit-project/cockpit-podman/pull/1993