### PR TITLE
app.scss: drop PF override which is no longer applicable

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -165,11 +165,6 @@
     }
 }
 
-// HACK: https://github.com/patternfly/patternfly/issues/6933
-.pf-v5-c-menu-toggle.pf-m-secondary {
-  background-color: var(--pf-v5-c-button--m-secondary--BackgroundColor);
-}
-
 .view-toggle-group {
     .pf-c-menu-toggle__button {
         display: flex;


### PR DESCRIPTION
This was fixed in October last year in PatternFly 5.

---

Pixel tests should prove this.