### PR TITLE
workflows: Move dependabot and reposchutz from Ubuntu 20.04 to 24.04

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -10,8 +10,7 @@ jobs:
       contents: read
       pull-requests: write
     timeout-minutes: 5
-    # 22.04's podman has issues with piping and causes tar errors
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ contains(github.event.pull_request.labels.*.name, 'node_modules') }}
 
     steps:

--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -6,8 +6,7 @@ on:
 jobs:
   check:
     name: Protection checks
-    # 22.04's podman has issues with piping and causes tar errors
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
20.04 will soon be EOL. "ubuntu-latest" is 24.04 now with a newer podman.

---

I got a warning from GitHub this morning that ubuntu-20.04 workflows will have three warning "brownouts" during March, and cease to exist on April 1.

We moved these workflows to -latest in https://github.com/cockpit-project/cockpit/commit/fa659236791fbdbab229bdaad2e544cc2ad1d2da and everything is fine.