### PR TITLE
test: Add hack around "Chromium ignores buttons" bug

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1676,7 +1676,13 @@ class TestFiles(testlib.MachineCase):
         b.click("button:contains('Edit permissions')")
 
         b.wait_text(".pf-v5-c-modal-box__title-text", "Permissions for 13 files")
-        b.assert_pixels(".pf-v5-c-modal-box", "multiple-files-permissions-modal")
+        # HACK: there is some really evil Chromium bug that often hides the "Change" button
+        # in screenshots; ensure it's there, and ignore it in the pixel comparison
+        # https://github.com/cockpit-project/cockpit/issues/21577
+        b.wait_text(".pf-v5-c-modal-box button.pf-m-primary", "Change")
+        b.assert_pixels(".pf-v5-c-modal-box", "multiple-files-permissions-modal",
+                        ignore=["button.pf-m-primary"])
+
         # Expand files
         b.wait_text(".pf-v5-c-expandable-section button", "Show all files")
         b.click(".pf-v5-c-expandable-section button")


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/issues/21577 has plagued us for long enough now, and nobody of us is able to figure out the root cause or proper workaround. This is *not* a race nor a PF/React/etc. bug, it really must be a Chromium bug. (See the issue for details)

As a bandaid, ignore the button for the pixel tests and assert that it exists.