### PR TITLE
Handle symlink permissions correctly

### DIFF
--- a/src/dialogs/permissions.tsx
+++ b/src/dialogs/permissions.tsx
@@ -128,6 +128,7 @@ const EditPermissionsModal = ({ dialogResult, items, path } : {
     const selected = items[0];
     const is_user_equal = items.every((item) => item.user === items[0].user);
     const is_group_equal = items.every((item) => item.group === items[0].group);
+    const has_symlinks = items.some((item) => item?.type === 'lnk');
 
     const [owner, setOwner] = useState(selected.user);
     const [mode, setMode] = useState(selected.mode ?? 0);
@@ -206,7 +207,7 @@ const EditPermissionsModal = ({ dialogResult, items, path } : {
                                     { superuser: "try", err: "message" });
 
             if (ownerChanged)
-                await cockpit.spawn(["chown", owner + ":" + group, ...file_paths],
+                await cockpit.spawn(["chown", "--no-dereference", owner + ":" + group, ...file_paths],
                                     { superuser: "try", err: "message" });
 
             dialogResult.resolve();
@@ -361,6 +362,7 @@ const EditPermissionsModal = ({ dialogResult, items, path } : {
                             </FormSelect>
                         </FormGroup>
                     </FormSection>}
+                    {!has_symlinks &&
                     <FormSection title={_("Access")}>
                         <FormGroup
                           label={_("Owner access")}
@@ -408,7 +410,7 @@ const EditPermissionsModal = ({ dialogResult, items, path } : {
                               readOnlyVariant="plain"
                             />
                         </FormGroup>}
-                    </FormSection>
+                    </FormSection>}
                     {selected.type === "reg" && executable_file_types.includes(selected?.category?.class || "file") &&
                         <Checkbox
                           id="is-executable"

--- a/test/check-application
+++ b/test/check-application
@@ -2304,9 +2304,10 @@ class TestFiles(testlib.MachineCase):
         self.assert_owner("/home/foouser/dir2/bye.txt", "foouser:foouser")
 
         # Non-admin copy to no write access directory shows permission denied error
-        b.drop_superuser()
         b.go("/files#/?path=/home/admin")
         self.assert_last_breadcrumb("admin")
+        b.wait_not_present('.pf-v5-c-empty-state')
+        b.drop_superuser()
         b.click("[data-item='newfile']")
         b.wait_visible("[data-item='newfile'].row-selected")
         b.click("#dropdown-menu")

--- a/test/check-application
+++ b/test/check-application
@@ -1482,6 +1482,22 @@ class TestFiles(testlib.MachineCase):
 
         check_perms_match(executable_file, '/home/admin')
 
+        # Symlinks
+        symlink = "link-to-uname"
+        m.execute(f"runuser -u admin -- ln -s /usr/bin/uname /home/admin/{symlink}")
+
+        # show no file mode permissions
+        open_permissions_dialog(symlink)
+        b.wait_not_present("#edit-permissions-owner-access")
+
+        # Changing ownership does not affect the symlink target
+        b.select_from_dropdown("#edit-permissions-group", "root")
+        b.click(".pf-v5-c-modal-box button.pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+
+        b.wait_in_text(f"[data-item='{symlink}'] .item-owner", "admin:root")
+        self.assertEqual(self.stat("%U:%G", "/usr/bin/uname"), "root:root")
+
         # Special file access permission cases
 
         # We normally don't provide "write-only" as an option unless someone


### PR DESCRIPTION
Symlinks have no permissions you can change so we shouldn't show this option. The owner/group can be changed and that is a valid use case however they shouldn't operate on the target.