### PR TITLE
focus delete button in delete modal

### DIFF
--- a/src/dialogs/delete.tsx
+++ b/src/dialogs/delete.tsx
@@ -85,9 +85,16 @@ const ConfirmDeletionDialog = ({ dialogResult, path, selected, setSelected } : {
           variant={ModalVariant.medium}
           isOpen
           onClose={() => dialogResult.resolve()}
+          elementToFocus="#delete-button"
           footer={
               <>
-                  <Button variant="danger" onClick={deleteItem}>{_("Delete")}</Button>
+                  <Button
+                    id="delete-button"
+                    variant="danger"
+                    onClick={deleteItem}
+                  >
+                      {_("Delete")}
+                  </Button>
                   <Button variant="link" onClick={() => dialogResult.resolve()}>{_("Cancel")}</Button>
               </>
           }


### PR DESCRIPTION
Change default focus to the Delete button instead of "x" on the top-right side of the modal. This allows workflow to delete files by hitting delete + enter key.