### PR TITLE
test: get a handle on those flakes!

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -928,6 +928,7 @@ class TestFiles(testlib.MachineCase):
         # Creating folder as superuser a non-logged in owned directory has the expected folder permissions
         b.go("/files#/?path=/root")
         self.assert_last_breadcrumb("root")
+        b.wait_text("#files-footer-owner", "root")
         self.addCleanup(m.execute, ['rm', '-rf', '/root/newdir'])
         self.create_directory("newdir")
         b.wait_visible("[data-item='newdir']")

--- a/test/check-application
+++ b/test/check-application
@@ -2139,7 +2139,7 @@ class TestFiles(testlib.MachineCase):
         b.click("#copy-item")
         b.go("files#/?path=/home/foouser")
         self.assert_last_breadcrumb("foouser")
-        b.wait_visible("[data-item='foouserfile']")
+        b.wait_text("#files-footer-owner", "foouser")
         b.click("#dropdown-menu")
         b.click("#paste-item")
         b.wait_visible("#paste-owner-modal")

--- a/test/check-application
+++ b/test/check-application
@@ -1390,7 +1390,7 @@ class TestFiles(testlib.MachineCase):
         self.assert_last_breadcrumb("testdir")
 
         # Via contextmenu
-        b.mouse("#files-card-parent", "contextmenu")
+        self.open_folder_context_menu()
         b.click(".contextMenu button:contains('Edit permissions')")
         b.wait_in_text(".pf-v5-c-modal-box__title-text", "testdir")
         b.select_from_dropdown("#edit-permissions-owner-access", "read-write")
@@ -3245,7 +3245,7 @@ class TestFiles(testlib.MachineCase):
         self.enter_files()
 
         def open_create_file_modal() -> None:
-            b.mouse("#files-card-parent", "contextmenu")
+            self.open_folder_context_menu()
             b.click(".contextMenu button:contains('Create file')")
             b.wait_visible(".file-create-modal")
             b.wait_text(".pf-v5-c-modal-box__title-text", "Create file")


### PR DESCRIPTION
Fix some b.go() issues where we don't really assert anything changes and thus we don't wait on `fsinfo` to load a new state and instead act on the old state.