### PR TITLE
Create symlink support

### DIFF
--- a/src/dialogs/symlink.tsx
+++ b/src/dialogs/symlink.tsx
@@ -1,0 +1,274 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { Modal, ModalVariant } from '@patternfly/react-core/dist/esm/components/Modal';
+import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
+import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { HelpIcon } from "@patternfly/react-icons";
+
+import cockpit, { BasicError } from 'cockpit';
+import { fsinfo, type FileInfo } from 'cockpit/fsinfo.ts';
+import { FormHelper } from 'cockpit-components-form-helper';
+import { InlineNotification } from 'cockpit-components-inline-notification';
+import { dirname } from 'cockpit-path.ts';
+import type { Dialogs, DialogResult } from 'dialogs';
+import { useInit } from 'hooks.ts';
+import { superuser } from 'superuser';
+import { fmt_to_fragments } from "utils";
+
+import { useFilesContext, type FolderFileInfo } from '../common.ts';
+import { get_owner_candidates } from '../ownership.tsx';
+
+function checkLinkName(candidate: string, entries: Record<string, FileInfo>, selectedFile?: FolderFileInfo) {
+    if (candidate === "") {
+        return _("Name cannot be empty");
+    } else if (candidate.length >= 256) {
+        return _("Name too long");
+    } else if (selectedFile && selectedFile.name === candidate) {
+        return _("Filename is the same as original name");
+    } else if (candidate in entries) {
+        if (entries[candidate].type === "dir") {
+            return _("Directory with the same name exists");
+        }
+        return _("File exists");
+    } else {
+        return null;
+    }
+}
+
+const _ = cockpit.gettext;
+
+type symlink_mode = "absolute" | "relative";
+
+const CreateLinkModal = ({ dialogResult, path, selected } : {
+    dialogResult: DialogResult<void>
+    path: string,
+    selected: FolderFileInfo,
+}) => {
+    const [errorMessage, setErrorMessage] = React.useState<string | undefined>();
+    const [symlinkName, setSymlinkName] = React.useState<string>(cockpit.format(_("link to $0"), selected.name));
+    const [symlinkError, setSymlinkError] = React.useState<string | null>(null);
+    const [mode, setMode] = React.useState<symlink_mode>("absolute");
+    const [user, setUser] = React.useState<cockpit.UserInfo| undefined>();
+
+    const { cwdInfo } = useFilesContext();
+
+    useInit(() => {
+        cockpit.user().then(user => setUser(user));
+    });
+
+    const createLink = async () => {
+        cockpit.assert(user !== undefined);
+        cockpit.assert(cwdInfo !== null);
+
+        const cmd = ["ln", "--symbolic"];
+        const target = `${path}${selected.name}`;
+        let owner = null;
+
+        let symlinkPath = symlinkName;
+        if (symlinkName.startsWith('..')) {
+            try {
+                symlinkPath = await cockpit.spawn(["realpath", `${path}${symlinkName}`], { superuser: "try" });
+                symlinkPath = symlinkPath.trim();
+            } catch (exc) {
+                const err = exc as BasicError;
+                setErrorMessage(err.toString());
+                console.warn("unable to obtain realpath", exc);
+                return;
+            }
+        }
+
+        let folder_info = cwdInfo;
+        if (symlinkName.startsWith('/') || symlinkName.startsWith('..')) {
+            try {
+                folder_info = await fsinfo(dirname(symlinkPath), ["user", "group", "mode"], { superuser: "try" });
+            } catch (exc) {
+                const err = exc as BasicError;
+                setErrorMessage(err.toString());
+                console.warn(`fsinfo failed for ${symlinkPath}`, exc);
+                return;
+            }
+        }
+
+        if (mode === "absolute") {
+            if (symlinkName.startsWith('/')) {
+                try {
+                    const realpath = await cockpit.spawn(["realpath", symlinkName]);
+                    cmd.push(target, realpath.trimEnd());
+                } catch (exc) {
+                    const err = exc as BasicError;
+                    setErrorMessage(err.toString());
+                    return;
+                }
+            } else if (symlinkName.startsWith('..')) {
+                cmd.push(target, symlinkPath);
+            } else {
+                cmd.push(target, symlinkName);
+            }
+        } else if (mode === "relative") {
+            cmd.push("--relative", target, symlinkName);
+        }
+
+        if (superuser.allowed) {
+            owner = [...get_owner_candidates(user, folder_info)][0];
+        }
+
+        try {
+            await cockpit.spawn(cmd, {
+                err: "message",
+                directory: path,
+                ...owner && { superuser: "require" }
+            });
+
+            if (owner !== null) {
+                await cockpit.spawn(["chown", "--no-dereference", owner, symlinkName], {
+                    directory: path,
+                    superuser: "require"
+                });
+            }
+        } catch (exc) {
+            const err = exc as BasicError;
+            setErrorMessage(err.toString());
+            return;
+        }
+
+        dialogResult.resolve();
+    };
+
+    return (
+        <Modal
+          position="top"
+          title={fmt_to_fragments(_("Create link to $0"), <b>{selected.name}</b>)}
+          variant={ModalVariant.medium}
+          isOpen
+          className="file-symlink-modal"
+          onClose={() => dialogResult.resolve()}
+          footer={
+              <>
+                  <Button
+                    variant="primary"
+                    onClick={() => {
+                        const filename_invalid = checkLinkName(symlinkName, cwdInfo?.entries || {}, selected);
+                        if (filename_invalid) {
+                            setSymlinkError(filename_invalid);
+                        } else {
+                            createLink();
+                        }
+                    }}
+                    isDisabled={errorMessage !== undefined ||
+                        symlinkError !== null ||
+                        cwdInfo === null ||
+                        user === null}
+                  >
+                      {_("Create link")}
+                  </Button>
+                  <Button variant="link" onClick={() => dialogResult.resolve()}>{_("Cancel")}</Button>
+              </>
+          }
+        >
+            {errorMessage &&
+            <InlineNotification
+              type="danger"
+              text={errorMessage}
+              isInline
+            />}
+            <Form
+              isHorizontal
+              onSubmit={e => {
+                  e.preventDefault();
+                  createLink();
+                  return false;
+              }}
+            >
+                <FormGroup fieldId="target-name" label={_("Target")}>
+                    <TextInput
+                      value={selected.name}
+                      readOnlyVariant="plain"
+                      id="target-name"
+                    />
+                </FormGroup>
+                <FormGroup fieldId="symlink-input" label={_("Symlink name")}>
+                    <TextInput
+                      validated={symlinkError ? "error" : "default"}
+                      value={symlinkName}
+                      onChange={(_, val) => {
+                          const filename_invalid = checkLinkName(val, cwdInfo?.entries || {}, selected);
+                          setSymlinkError(filename_invalid);
+                          setErrorMessage(undefined);
+                          setSymlinkName(val);
+                      }}
+                      onFocus={(event) => event.target.setSelectionRange(0, cockpit.format(_("link to $0"), "").length)}
+                      id="symlink-input" autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+                    />
+                    <FormHelper fieldId="symlink-input" helperTextInvalid={symlinkError} />
+                </FormGroup>
+                <FormGroup
+                  fieldId="symlink-type"
+                  label={_("Type")}
+                  isInline
+                  labelIcon={
+                      <Popover
+                        headerContent={_("Absolute vs. Relative")}
+                        bodyContent={
+                            <>
+                                {/* eslint-disable-next-line max-len */}
+                                <p>{_("Absolute symlinks are ideal when referring to files or directories that won't move, such as system files.")}</p>
+                                <br />
+                                {/* eslint-disable-next-line max-len */}
+                                <p>{_("Relative symlinks use a shorter local path to a target. This is useful when both a symlink and target might move at the same time, such as when renaming or moving a parent directory.")}</p>
+                            </>
+                        }
+                      >
+                          <Button
+                            isInline
+                            variant="plain"
+                            onClick={e => e.preventDefault()}
+                          >
+                              <HelpIcon />
+                          </Button>
+                      </Popover>
+                  }
+                >
+                    <Radio
+                      id="absolute"
+                      name="absolute"
+                      label={_("Absolute")}
+                      isChecked={mode === "absolute"}
+                      onChange={() => setMode("absolute")}
+                    />
+                    <Radio
+                      id="relative"
+                      name="relative"
+                      label={_("Relative")}
+                      isChecked={mode === "relative"}
+                      onChange={() => setMode("relative")}
+                    />
+                </FormGroup>
+            </Form>
+        </Modal>
+    );
+};
+
+export function create_link(dialogs: Dialogs, path: string, selected: FolderFileInfo) {
+    dialogs.run(CreateLinkModal, { path, selected });
+}

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -36,6 +36,7 @@ import { edit_file, MAX_EDITOR_FILE_SIZE } from './dialogs/editor.tsx';
 import { show_create_directory_dialog } from './dialogs/mkdir.tsx';
 import { edit_permissions } from './dialogs/permissions.jsx';
 import { show_rename_dialog } from './dialogs/rename.tsx';
+import { create_link } from "./dialogs/symlink.tsx";
 import { downloadFile } from './download.tsx';
 
 const _ = cockpit.gettext;
@@ -148,6 +149,15 @@ export function get_menu_items(
                     id: "open-file",
                     title: _("Open text file"),
                     onClick: () => edit_file(dialogs, path + item.name)
+                },
+                { type: "divider" },
+            );
+        if (item.type === 'reg' || item.type === "dir")
+            menuItems.push(
+                {
+                    id: "create-symlink",
+                    title: _("Create link"),
+                    onClick: () => create_link(dialogs, path, item)
                 },
                 { type: "divider" },
             );

--- a/test/check-application
+++ b/test/check-application
@@ -3331,6 +3331,193 @@ class TestFiles(testlib.MachineCase):
         b.click(".contextMenu button:contains('Create file')")
         b.wait_in_text("h4.pf-v5-c-alert__title", "Cannot create file in current directory")
 
+    def testCreateLink(self) -> None:
+        b = self.browser
+        m = self.machine
+
+        self.enter_files()
+
+        test_filename = "filename.txt"
+        m.execute(['runuser', '-u', 'admin', 'touch', "/home/admin/existing.txt", f"/home/admin/{test_filename}"])
+        test_directory = 'testdir'
+        m.execute(['runuser', '-u', 'admin', 'mkdir', f'/home/admin/{test_directory}'])
+        b.wait_visible("[data-item='existing.txt']")
+        b.wait_visible(f"[data-item='{test_filename}']")
+        b.wait_visible(f"[data-item='{test_directory}']")
+
+        def create_symlink(filename: str) -> None:
+            b.mouse(f"[data-item='{filename}']", "contextmenu")
+            b.click(".contextMenu button:contains('Create link')")
+            b.wait_in_text(".pf-v5-c-modal-box__title-text", f"Create link to {filename}")
+
+        def assert_link(link: str, expected: str, owner: str | None = None) -> None:
+            self.assertEqual(m.execute(f"readlink '{link}'").strip(),
+                             expected)
+            if owner is not None:
+                self.assertEqual(self.stat("%U:%G", link), owner)
+
+        # Absolute
+
+        # normal filename
+        create_symlink(test_filename)
+        b.wait_val("#target-name", test_filename)
+        b.wait_val("#symlink-input", f"link to {test_filename}")
+        self.assertTrue(b.get_checked("#absolute"))
+        b.assert_pixels(".file-symlink-modal", "create-link-dialog")
+        b.click(".pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        assert_link(f"/home/admin/link to {test_filename}",
+                    f"/home/admin/{test_filename}",
+                    "admin:admin")
+
+        # absolute path given
+        create_symlink(test_filename)
+        b.set_input_text("#symlink-input", f"{self.vm_tmpdir}/absolute-absolute")
+        b.click(".pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        assert_link(f"{self.vm_tmpdir}/absolute-absolute",
+                    f"/home/admin/{test_filename}",
+                    "root:root")
+
+        # not canonical path
+        create_symlink(test_filename)
+        b.set_input_text("#symlink-input", f"/..{self.vm_tmpdir}/absolute-relative")
+        b.click(".pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        assert_link(f"{self.vm_tmpdir}/absolute-relative",
+                    f"/home/admin/{test_filename}",
+                    "root:root")
+
+        # relative path given
+        create_symlink(test_filename)
+        b.set_input_text("#symlink-input", "../absolute-relative")
+        self.addCleanup(m.execute, "rm /home/absolute-relative")
+        b.click(".pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        assert_link("/home/absolute-relative",
+                    f"/home/admin/{test_filename}",
+                    "root:root")
+
+        # Relative
+        create_symlink(test_filename)
+        b.wait_val("#target-name", test_filename)
+        b.set_input_text("#symlink-input", "relative")
+        b.set_checked("#relative", True)
+        b.click(".pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        assert_link("/home/admin/relative",
+                    test_filename,
+                    "admin:admin")
+
+        # absolute path given
+        create_symlink(test_filename)
+        b.set_input_text("#symlink-input", f"{self.vm_tmpdir}/relative-absolute")
+        b.set_checked("#relative", True)
+        b.click(".pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        assert_link(f"{self.vm_tmpdir}/relative-absolute",
+                    f"../../../home/admin/{test_filename}",
+                    "root:root")
+
+        # not canonical path
+        create_symlink(test_filename)
+        b.set_input_text("#symlink-input", f"/../{self.vm_tmpdir}/relative-relative")
+        b.set_checked("#relative", True)
+        b.click(".pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        assert_link(f"{self.vm_tmpdir}/relative-relative",
+                    f"../../../home/admin/{test_filename}",
+                    "root:root")
+
+        # relative path
+        create_symlink(test_filename)
+        b.set_input_text("#symlink-input", "../relative-relative")
+        b.set_checked("#relative", True)
+        self.addCleanup(m.execute, "rm /home/relative-relative")
+        b.click(".pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        assert_link("/home/relative-relative",
+                    f"admin/{test_filename}",
+                    "root:root")
+
+        # directory
+        create_symlink(test_directory)
+        b.wait_val("#target-name", test_directory)
+        b.wait_val("#symlink-input", f"link to {test_directory}")
+        b.click(".pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        assert_link(f"/home/admin/link to {test_directory}",
+                    f"/home/admin/{test_directory}",
+                    "admin:admin")
+
+        # normal user
+        b.drop_superuser()
+
+        # absolute
+        create_symlink(test_filename)
+        b.set_input_text("#symlink-input", "user-absolute")
+        b.click(".pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        assert_link("/home/admin/user-absolute",
+                    f"/home/admin/{test_filename}",
+                    "admin:admin")
+
+        # relative
+        create_symlink(test_filename)
+        b.set_checked("#relative", True)
+        b.set_input_text("#symlink-input", "user-relative")
+        b.click(".pf-m-primary")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        assert_link("/home/admin/user-relative",
+                    test_filename,
+                    "admin:admin")
+
+        # validation
+        create_symlink(test_filename)
+        b.set_input_text("#symlink-input", "")
+        b.wait_text(".file-symlink-modal .pf-v5-c-helper-text__item-text", "Name cannot be empty")
+        b.wait_visible("button.pf-m-primary:disabled")
+
+        b.set_input_text("#symlink-input", "existing.txt")
+        b.wait_text(".file-symlink-modal .pf-v5-c-helper-text__item-text", "File exists")
+
+        b.set_input_text("#symlink-input", test_filename)
+        b.wait_text(".file-symlink-modal .pf-v5-c-helper-text__item-text",
+                    "Filename is the same as original name")
+
+        b.set_input_text("#symlink-input", test_directory)
+        b.wait_text(".file-symlink-modal .pf-v5-c-helper-text__item-text",
+                    "Directory with the same name exists")
+
+        b.set_input_text("#symlink-input", "a" * 260)
+        b.wait_text(".file-symlink-modal .pf-v5-c-helper-text__item-text",
+                    "Name too long")
+        b.wait_visible("button.pf-m-primary:disabled")
+
+        # no permissions
+        b.set_input_text("#symlink-input", "/bar")
+        b.click(".pf-m-primary")
+        b.wait_in_text(".pf-v5-c-alert__title", "Permission denied")
+        b.wait_visible("button.pf-m-primary:disabled")
+
+        # dialogs cwdInfo not updated, still validated on create
+        b.set_input_text("#symlink-input", "new")
+        m.execute("mkdir /home/admin/new")
+        b.wait_visible("[data-item='new']")
+        b.click(".file-symlink-modal .pf-m-primary")
+        b.wait_text(".file-symlink-modal .pf-v5-c-helper-text__item-text",
+                    "Directory with the same name exists")
+        b.wait_visible("button.pf-m-primary:disabled")
+
+        # Non-existant target
+        b.set_input_text("#symlink-input", "../non-existant/not/really/here")
+        b.click(".file-symlink-modal .pf-m-primary")
+        b.wait_in_text(".pf-v5-c-alert__title", "No such file or directory")
+        b.wait_visible("button.pf-m-primary:disabled")
+
+        b.click(".file-symlink-modal .pf-m-link")
+        b.wait_not_present(".pf-v5-c-modal-box")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Allow the creation of absolute or relative symlinks from the target. The symlink input field can be a filename, an absolute or relative path and are either symlinked as relative or absolute depending on the selected option.

The symlink permissions are not configurable and by default based on the owner of the directory so creating a symlink as administrator in the users home directory creates it as `admin:admin`.

![image](https://github.com/user-attachments/assets/be2f7dd2-bab0-481b-bfde-a32570140297)

---

# Files: Create symlink support

Files can now create relative or absolute symlinks for files or directories in the current directory.

![image](https://github.com/user-attachments/assets/c9787202-acb1-42ba-8768-dd9c9ae72192)