### PR TITLE
test: use modern typing hints

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -10,7 +10,6 @@ import shlex
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import List, Optional
 
 # import Cockpit's machinery for test VMs and its browser test API
 import testlib
@@ -2381,7 +2380,7 @@ class TestFiles(testlib.MachineCase):
         def dir_file_count(directory: str) -> int:
             return int(m.execute(f"find {directory} -mindepth 1 -maxdepth 1 | wc -l").strip())
 
-        def assert_upload_alert(files: List[str], owner_group: Optional[str] = None, *,
+        def assert_upload_alert(files: list[str], owner_group: str | None = None, *,
                                 close: bool = True, pixel_test: bool = False) -> None:
             title = ""
             description = ""


### PR DESCRIPTION
Since 3.9 we can use `list[str]` or `| None` and since our testing container has a way more modern version this is safe to change.