### PR TITLE
test: Enable testUpload on Firefox

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -2363,7 +2363,6 @@ class TestFiles(testlib.MachineCase):
         b.click(".pf-v5-c-alert__action button")
         b.wait_not_present("[data-item='newfile']")
 
-    @testlib.skipBrowser(".upload_files() doesn't work on Firefox", "firefox")
     def testUpload(self) -> None:
         b = self.browser
         m = self.machine


### PR DESCRIPTION
This works fine now.

---

... at least locally; the comment doesn't say whether it e.g. only doesn't work in TF or so, let's see.