### PR TITLE
test: fix flake in testErrors

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1826,7 +1826,8 @@ class TestFiles(testlib.MachineCase):
         # Make a directory that's not readable to the admin user
         m.execute("mkdir /home/admin/testdir && chmod 400 /home/admin/testdir")
         b.mouse("[data-item='testdir']", "dblclick")
-        b.wait_not_present(".pf-v5-c-empty-state")
+        self.assert_last_breadcrumb("testdir")
+        b.wait_in_text(".pf-v5-c-empty-state", "Directory is empty")
         b.drop_superuser()
         b.wait_in_text(".pf-v5-c-empty-state", "Permission denied")
         b.assert_pixels(".pf-v5-c-page__main", "error-folder-view")

--- a/test/check-application
+++ b/test/check-application
@@ -935,7 +935,7 @@ class TestFiles(testlib.MachineCase):
 
         m.execute('useradd -m testuser')
         b.go('/files#/?path=/home/testuser')
-        b.wait_not_present('.pf-v5-c-empty-state')
+        b.wait_text("#files-footer-owner", "testuser")
         self.create_directory('newdir')
         b.wait_visible("[data-item='newdir']")
         self.assert_owner('/home/testuser', 'testuser:testuser')


### PR DESCRIPTION
The test changes into an empty directory so waiting for the empty state not to be present is a race.