### PR TITLE
packaging: drop nodejs build requirement

### DIFF
--- a/packaging/cockpit-files.spec.in
+++ b/packaging/cockpit-files.spec.in
@@ -6,8 +6,6 @@ License: LGPL-2.1-or-later
 
 Source0: https://github.com/cockpit-project/cockpit-files/releases/download/%{version}/%{name}-%{version}.tar.xz
 BuildArch: noarch
-ExclusiveArch: %{nodejs_arches} noarch
-BuildRequires: nodejs
 BuildRequires: make
 %if 0%{?suse_version}
 # Suse's package has a different name


### PR DESCRIPTION
Our Fedora/RHEL packaging does not do any building in the `%build` step.