### PR TITLE
Provide `user` in the FilesContext

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -184,7 +184,7 @@ export const Application = ({ user }: { user: cockpit.UserInfo }) => {
 
     return (
         <Page>
-            <FilesContext.Provider value={{ addAlert, removeAlert, cwdInfo }}>
+            <FilesContext.Provider value={{ addAlert, removeAlert, cwdInfo, user }}>
                 <WithDialogs>
                     <AlertGroup isToast isLiveRegion>
                         {alerts.map(alert => (

--- a/src/common.ts
+++ b/src/common.ts
@@ -41,12 +41,14 @@ interface FilesContextType {
                actionLinks?: React.ReactNode) => void,
     removeAlert: (key: string) => void,
     cwdInfo: FileInfo | null,
+    user: cockpit.UserInfo | null,
 }
 
 export const FilesContext = React.createContext({
     addAlert: () => console.warn("FilesContext not initialized"),
     removeAlert: () => console.warn("FilesContext not initialized"),
     cwdInfo: null,
+    user: null,
 } as FilesContextType);
 
 export const useFilesContext = () => useContext(FilesContext);

--- a/src/dialogs/copyPasteOwnership.tsx
+++ b/src/dialogs/copyPasteOwnership.tsx
@@ -141,15 +141,14 @@ const CopyPasteAsOwnerModal = ({
     // @ts-expect-error superuser.js is not typed
     useEvent(superuser, "changed");
     const [selectedOwner, setSelectedOwner] = useState<string | undefined>();
-    const { cwdInfo, addAlert } = useFilesContext();
+    const { cwdInfo, addAlert, user } = useFilesContext();
     const [candidatesMap, setCandidatesMap] = useState<Map<string, string> | undefined>();
 
     useInit(async () => {
-        const userInfo = await cockpit.user();
         let map: Map<string, string> = new Map();
 
-        if (superuser.allowed && userInfo && cwdInfo) {
-            map = makeCandidatesMap(userInfo, cwdInfo, clipboard);
+        if (superuser.allowed && user && cwdInfo) {
+            map = makeCandidatesMap(user, cwdInfo, clipboard);
             if (selectedOwner === undefined) {
                 setSelectedOwner(map.keys().next().value);
             }

--- a/src/dialogs/create-file.tsx
+++ b/src/dialogs/create-file.tsx
@@ -95,17 +95,16 @@ const CreateFileModal = ({ dialogResult, path } : {
     const [createError, setCreateError] = React.useState<string | null>(null);
     const [candidates, setCandidates] = React.useState<string[]>([]);
 
-    const { cwdInfo } = useFilesContext();
+    const { cwdInfo, user } = useFilesContext();
 
     useInit(() => {
-        cockpit.user().then(user => {
-            const owner_candidates = [];
-            if (superuser.allowed && cwdInfo) {
-                owner_candidates.push(...get_owner_candidates(user, cwdInfo));
-                setOwner(owner_candidates[0]);
-                setCandidates(owner_candidates);
-            }
-        });
+        cockpit.assert(user !== null, "user cannot be null");
+        const owner_candidates = [];
+        if (superuser.allowed && cwdInfo) {
+            owner_candidates.push(...get_owner_candidates(user, cwdInfo));
+            setOwner(owner_candidates[0]);
+            setCandidates(owner_candidates);
+        }
     });
 
     const handleEscape = (event: KeyboardEvent) => {

--- a/src/dialogs/mkdir.tsx
+++ b/src/dialogs/mkdir.tsx
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
@@ -67,16 +67,11 @@ const CreateDirectoryModal = ({ currentPath, dialogResult } : {
     const [nameError, setNameError] = useState<string | undefined>();
     const [errorMessage, setErrorMessage] = useState<string | undefined>();
     const [owner, setOwner] = useState<string | undefined>();
-    const [user, setUser] = useState<cockpit.UserInfo| undefined>();
     const createDirectory = () => {
         const path = currentPath + name;
         create_directory(path, owner).then(dialogResult.resolve, err => setErrorMessage(err.message));
     };
-    const { cwdInfo } = useFilesContext();
-
-    useEffect(() => {
-        cockpit.user().then(user => setUser(user));
-    }, []);
+    const { cwdInfo, user } = useFilesContext();
 
     const candidates = [];
     if (superuser.allowed && user && cwdInfo) {

--- a/src/files-breadcrumbs.tsx
+++ b/src/files-breadcrumbs.tsx
@@ -39,11 +39,10 @@ const _ = cockpit.gettext;
 
 function BookmarkButton({ path }: { path: string }) {
     const [isOpen, setIsOpen] = React.useState(false);
-    const [user, setUser] = React.useState<cockpit.UserInfo | null>(null);
     const [bookmarks, setBookmarks] = React.useState<string[]>([]);
     const [bookmarkHandle, setBookmarkHandle] = React.useState<cockpit.FileHandle<string> | null>(null);
 
-    const { addAlert, cwdInfo } = useFilesContext();
+    const { addAlert, cwdInfo, user } = useFilesContext();
 
     const defaultBookmarks = [];
     if (user?.home) {
@@ -72,10 +71,8 @@ function BookmarkButton({ path }: { path: string }) {
     };
 
     useInit(async () => {
-        const user_info = await cockpit.user();
-        setUser(user_info);
-
-        const handle = cockpit.file(`${user_info.home}/.config/gtk-3.0/bookmarks`);
+        cockpit.assert(user !== null, "user is null in useInit");
+        const handle = cockpit.file(`${user.home}/.config/gtk-3.0/bookmarks`);
         setBookmarkHandle(handle);
 
         handle.watch((content) => {

--- a/src/upload-button.tsx
+++ b/src/upload-button.tsx
@@ -156,7 +156,7 @@ export const UploadButton = ({
     path: string,
 }) => {
     const ref = useRef<HTMLInputElement>(null);
-    const { addAlert, removeAlert, cwdInfo } = useFilesContext();
+    const { addAlert, removeAlert, cwdInfo, user } = useFilesContext();
     const dialogs = useDialogs();
     const [showPopover, setPopover] = React.useState(false);
     const { uploadedFiles, setUploadedFiles } = useContext(UploadContext);
@@ -183,8 +183,7 @@ export const UploadButton = ({
 
         // When we are superuser upload as the owner of the directory and allow
         // the user to later change ownership if required.
-        const user = await cockpit.user();
-        if (superuser.allowed && cwdInfo) {
+        if (superuser.allowed && cwdInfo && user) {
             const candidates = get_owner_candidates(user, cwdInfo);
             owner = [...candidates][0];
         }
@@ -400,6 +399,7 @@ export const UploadButton = ({
         addAlert,
         removeAlert,
         cwdInfo,
+        user,
         dialogs,
         path,
         setUploadedFiles,


### PR DESCRIPTION
Now that `Application` is guaranteed to have a valid `user` it can also be provided via the FilesContext. This removes the needs for a `useInit` or `useEffect` to obtain the `user` object in dialogs or other components.

---

This is sparked by your comment in the symlink PR @martinpitt instead of passing it down everywhere I just added it to the widely available context. In reality it can never be `null` but due to how `createContext works` it has to be optionally null.