### PR TITLE
src: stop plumbing 'user' around

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -72,7 +72,7 @@ const get_path = (options: Location['options']) => {
     return currentPath;
 };
 
-export const Application = ({ user }: { user: cockpit.UserInfo }) => {
+export const Application = () => {
     const [location, setLocation] = useState(cockpit.location);
     const [loading, setLoading] = useState(true);
     const [loadingFiles, setLoadingFiles] = useState(true);
@@ -98,7 +98,7 @@ export const Application = ({ user }: { user: cockpit.UserInfo }) => {
 
         // On initial load redirect to the users home directory
         if (cockpit.location.options.path === undefined) {
-            cockpit.location.replace("/", { path: encodeURIComponent(user.home) });
+            cockpit.location.replace("/", { path: encodeURIComponent(cockpit.info.user.home) });
         }
 
         return () => cockpit.removeEventListener("locationchanged", update);
@@ -184,7 +184,7 @@ export const Application = ({ user }: { user: cockpit.UserInfo }) => {
 
     return (
         <Page>
-            <FilesContext.Provider value={{ addAlert, removeAlert, cwdInfo, user }}>
+            <FilesContext.Provider value={{ addAlert, removeAlert, cwdInfo }}>
                 <WithDialogs>
                     <AlertGroup isToast isLiveRegion>
                         {alerts.map(alert => (

--- a/src/common.ts
+++ b/src/common.ts
@@ -41,14 +41,12 @@ interface FilesContextType {
                actionLinks?: React.ReactNode) => void,
     removeAlert: (key: string) => void,
     cwdInfo: FileInfo | null,
-    user: cockpit.UserInfo | null,
 }
 
 export const FilesContext = React.createContext({
     addAlert: () => console.warn("FilesContext not initialized"),
     removeAlert: () => console.warn("FilesContext not initialized"),
     cwdInfo: null,
-    user: null,
 } as FilesContextType);
 
 export const useFilesContext = () => useContext(FilesContext);

--- a/src/dialogs/copyPasteOwnership.tsx
+++ b/src/dialogs/copyPasteOwnership.tsx
@@ -93,11 +93,11 @@ function ownershipTypes(files: FolderFileInfo[]) {
     return [...owners];
 }
 
-function makeCandidatesMap(currentUser: cockpit.UserInfo, cwdInfo: FileInfo, clipboard: ClipboardInfo) {
+function makeCandidatesMap(cwdInfo: FileInfo, clipboard: ClipboardInfo) {
     // keys in Map() are ordered in the same order as they were inserted
     // and has no duplicates. Only the first insertion.
     const map: Map<string, string> = new Map();
-    const candidates = get_owner_candidates(currentUser, cwdInfo);
+    const candidates = get_owner_candidates(cwdInfo);
 
     // also add current ownership if it is same for all files (shallow check)
     const firstFile = clipboard.files[0];
@@ -141,14 +141,14 @@ const CopyPasteAsOwnerModal = ({
     // @ts-expect-error superuser.js is not typed
     useEvent(superuser, "changed");
     const [selectedOwner, setSelectedOwner] = useState<string | undefined>();
-    const { cwdInfo, addAlert, user } = useFilesContext();
+    const { cwdInfo, addAlert } = useFilesContext();
     const [candidatesMap, setCandidatesMap] = useState<Map<string, string> | undefined>();
 
     useInit(async () => {
         let map: Map<string, string> = new Map();
 
-        if (superuser.allowed && user && cwdInfo) {
-            map = makeCandidatesMap(user, cwdInfo, clipboard);
+        if (superuser.allowed && cwdInfo) {
+            map = makeCandidatesMap(cwdInfo, clipboard);
             if (selectedOwner === undefined) {
                 setSelectedOwner(map.keys().next().value);
             }

--- a/src/dialogs/create-file.tsx
+++ b/src/dialogs/create-file.tsx
@@ -95,13 +95,12 @@ const CreateFileModal = ({ dialogResult, path } : {
     const [createError, setCreateError] = React.useState<string | null>(null);
     const [candidates, setCandidates] = React.useState<string[]>([]);
 
-    const { cwdInfo, user } = useFilesContext();
+    const { cwdInfo } = useFilesContext();
 
     useInit(() => {
-        cockpit.assert(user !== null, "user cannot be null");
         const owner_candidates = [];
         if (superuser.allowed && cwdInfo) {
-            owner_candidates.push(...get_owner_candidates(user, cwdInfo));
+            owner_candidates.push(...get_owner_candidates(cwdInfo));
             setOwner(owner_candidates[0]);
             setCandidates(owner_candidates);
         }

--- a/src/dialogs/mkdir.tsx
+++ b/src/dialogs/mkdir.tsx
@@ -71,11 +71,11 @@ const CreateDirectoryModal = ({ currentPath, dialogResult } : {
         const path = currentPath + name;
         create_directory(path, owner).then(dialogResult.resolve, err => setErrorMessage(err.message));
     };
-    const { cwdInfo, user } = useFilesContext();
+    const { cwdInfo } = useFilesContext();
 
     const candidates = [];
-    if (superuser.allowed && user && cwdInfo) {
-        candidates.push(...get_owner_candidates(user, cwdInfo));
+    if (superuser.allowed && cwdInfo) {
+        candidates.push(...get_owner_candidates(cwdInfo));
         if (owner === undefined) {
             setOwner(candidates[0]);
         }
@@ -95,7 +95,6 @@ const CreateDirectoryModal = ({ currentPath, dialogResult } : {
                     onClick={createDirectory}
                     isDisabled={errorMessage !== undefined ||
                         nameError !== undefined ||
-                        user === null ||
                         cwdInfo === null}
                   >
                       {_("Create")}

--- a/src/files-breadcrumbs.tsx
+++ b/src/files-breadcrumbs.tsx
@@ -42,14 +42,14 @@ function BookmarkButton({ path }: { path: string }) {
     const [bookmarks, setBookmarks] = React.useState<string[]>([]);
     const [bookmarkHandle, setBookmarkHandle] = React.useState<cockpit.FileHandle<string> | null>(null);
 
-    const { addAlert, cwdInfo, user } = useFilesContext();
+    const { addAlert, cwdInfo } = useFilesContext();
 
     const defaultBookmarks = [];
-    if (user?.home) {
-        // Ensure the home dir has a trailing / like the path
-        const home_dir = user.home.endsWith('/') ? user.home : `${user.home}/`;
-        defaultBookmarks.push({ name: _("Home"), loc: home_dir }); // TODO: add trash
-    }
+
+    // Ensure the home dir has a trailing / like the path
+    const home = cockpit.info.user.home;
+    const home_dir = home.endsWith('/') ? home : `${home}/`;
+    defaultBookmarks.push({ name: _("Home"), loc: home_dir }); // TODO: add trash
 
     const parse_uri = (line: string) => {
         // Drop everything after the space, we don't show renames
@@ -71,8 +71,7 @@ function BookmarkButton({ path }: { path: string }) {
     };
 
     useInit(async () => {
-        cockpit.assert(user !== null, "user is null in useInit");
-        const handle = cockpit.file(`${user.home}/.config/gtk-3.0/bookmarks`);
+        const handle = cockpit.file(`${home}/.config/gtk-3.0/bookmarks`);
         setBookmarkHandle(handle);
 
         handle.watch((content) => {
@@ -89,7 +88,6 @@ function BookmarkButton({ path }: { path: string }) {
     });
 
     const saveBookmark = async () => {
-        cockpit.assert(user !== null, "user is null while saving bookmarks");
         cockpit.assert(bookmarkHandle !== null, "bookmarkHandle is null while saving bookmarks");
         const bookmark_file = basename(bookmarkHandle.path);
         const config_dir = bookmarkHandle.path.replace(bookmark_file, "");
@@ -132,9 +130,6 @@ function BookmarkButton({ path }: { path: string }) {
         }
         setIsOpen(false);
     };
-
-    if (user === null)
-        return null;
 
     let actionText = null;
     if (!defaultBookmarks.some(bkmark => bkmark.loc === path)) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,9 +37,22 @@ import { Application } from "./app.tsx";
  */
 import "./app.scss";
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
+    try {
+        await cockpit.init();
+    } catch (exp: any) { /* eslint-disable-line @typescript-eslint/no-explicit-any */
+        /* Remove this when we take a dependency on Cockpit 336 ('info' channnel in the bridge) */
+        if (exp.problem === 'not-supported') {
+            const user = await cockpit.user();
+            cockpit.info.user = {
+                fullname: user.full_name,
+                group: user.groups[0],
+                uid: user.id,
+                ...user,
+            };
+        }
+    }
+
     const root = createRoot(document.getElementById("app")!);
-    cockpit.user().then(user => {
-        root.render(<Application user={user} />);
-    });
+    root.render(<Application />);
 });

--- a/src/ownership.tsx
+++ b/src/ownership.tsx
@@ -6,7 +6,7 @@ import type { FileInfo } from 'cockpit/fsinfo.ts';
 // disabled, it's all a moot point, since we don't have any choice (in which
 // case this function should not be used).  This is very much a heuristic, and
 // might change in the future.
-export function get_owner_candidates(user: cockpit.UserInfo, info: FileInfo) {
+export function get_owner_candidates(info: FileInfo) {
     // In case the parent directory is setgid, we always override the group we
     // create as, mirroring the usual POSIX behaviour.  There are other cases
     // where the "BSD group semantics" come into play (like mount options) but
@@ -32,12 +32,7 @@ export function get_owner_candidates(user: cockpit.UserInfo, info: FileInfo) {
     // The last option is always available: create as the normal user.  In case
     // of something inside of the user's home directory, this was probably the
     // first option as well...
-    // The first group from `cockpit.user()` is guaranteed to be the users default group
-    if (user.groups.length >= 1) {
-        candidates.add(`${user.name || user.id}:${setgid || user.groups[0] || user.gid}`);
-    } else {
-        candidates.add(`${user.name || user.id}:${setgid || user.gid}`);
-    }
+    candidates.add(`${cockpit.info.user.name}:${setgid || cockpit.info.user.group}`);
 
     return candidates;
 }

--- a/src/upload-button.tsx
+++ b/src/upload-button.tsx
@@ -156,7 +156,7 @@ export const UploadButton = ({
     path: string,
 }) => {
     const ref = useRef<HTMLInputElement>(null);
-    const { addAlert, removeAlert, cwdInfo, user } = useFilesContext();
+    const { addAlert, removeAlert, cwdInfo } = useFilesContext();
     const dialogs = useDialogs();
     const [showPopover, setPopover] = React.useState(false);
     const { uploadedFiles, setUploadedFiles } = useContext(UploadContext);
@@ -183,8 +183,8 @@ export const UploadButton = ({
 
         // When we are superuser upload as the owner of the directory and allow
         // the user to later change ownership if required.
-        if (superuser.allowed && cwdInfo && user) {
-            const candidates = get_owner_candidates(user, cwdInfo);
+        if (superuser.allowed && cwdInfo) {
+            const candidates = get_owner_candidates(cwdInfo);
             owner = [...candidates][0];
         }
 
@@ -399,7 +399,6 @@ export const UploadButton = ({
         addAlert,
         removeAlert,
         cwdInfo,
-        user,
         dialogs,
         path,
         setUploadedFiles,


### PR DESCRIPTION
Instead of using `cockpit.user()`, switch to getting the same information from `cockpit.info`.  We have to call `cockpit.init()` to have that initialized, but once it's done, we no longer have to route the data around through the entire codebase.

This PR is a sort of proof of concept for the work in https://github.com/cockpit-project/cockpit/pull/21733

*Manual testing*: You can test this locally by manually updating the cockpit commit in the Makefile to whatever the latest in https://github.com/cockpit-project/cockpit/pull/21733 is, then building an image of that branch *from inside cockpit project* using `test/image-prepare`, then running that image with `vm-run -s cockpit.socket`, then (back in cockpit-files) running `./build.js -rc` inside of this branch in cockpit-files, then logging in and looking around.  I've done that and things seem to be working ok.

Huge shoutout goes out to TypeScript for making this refactoring task absolutely trivial.

todo:
 - [x] https://github.com/cockpit-project/cockpit/pull/21733
 - [x] bump our cockpitlib depend in the Makefile
 - [x] Cockpit release: https://github.com/cockpit-project/cockpit/releases/tag/336
 - [ ] ~Cockpit release in distros~
 - [ ] ~bump our cockpit depend to the released version with the bridge changes~
 - [x] polyfill `cockpit.info.user` for old bridges