### PR TITLE
Drop pf-m-redhat-font

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,7 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
     <script src="../manifests.js"></script>
 </head>
 
-<body class="pf-m-redhat-font">
+<body>
     <div class="ct-page-fill" id="app"></div>
 </body>
 </html>


### PR DESCRIPTION
This no longer exists as class in PF since the PF 3->4 migration.

See also: https://github.com/cockpit-project/cockpit/commit/517c8e05fed676a6bc7751a01debfdf4f644fe1b