### PR TITLE
Temporary set max_read_size of Cockpit to MAX_SAFE_INTEGER

### DIFF
--- a/src/download.tsx
+++ b/src/download.tsx
@@ -31,7 +31,10 @@ export function downloadFile(currentPath: string, selected: FolderFileInfo) {
         external: {
             "content-disposition": `attachment; filename="${selected.name}"`,
             "content-type": "application/octet-stream",
-        }
+        },
+        // HACK: The Cockpit bridge has no way of saying "unlimited" until it supports passing -1
+        // https://github.com/cockpit-project/cockpit/pull/21556
+        max_read_size: Number.MAX_SAFE_INTEGER,
     });
 
     const encodedPayload = new TextEncoder().encode(payload);


### PR DESCRIPTION
The Python bridge does have a maximum read size limit while the C bridge did. We want to add a maximum read size back to 16MB but that would break files users and we can't introduce an "unlimited" option (-1) as that would be incompatible with older Python bridge versions. So temporarily we set the max size to something very big `MAX_SAFE_INTEGER` which is 2^53. When we bump the cockpit-bridge requirement in files we can set it to "unlimited".