### PR TITLE
workflows: run codeql workflow on ubuntu-latest

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
There is no reason to stick with Ubuntu 22.04.