### PR TITLE
test: Fix testContextMenu for real mouse clicks, fix test{Basic,Download} flakes

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -209,14 +209,6 @@ class TestFiles(testlib.MachineCase):
         b.set_input_text("input[placeholder='Filter directory']", "")
         self.browser.wait_js_cond("ph_count('#folder-view tbody tr') > 1")
 
-        # Big file downloads fine, runs in this test as running two downloads
-        # in the same test causes issues with Chromium. This takes ~ 40 seconds.
-        m.execute("truncate -s 1500M /home/admin/test.iso")
-        b.wait_visible("[data-item='test.iso']")
-        b.mouse("[data-item='test.iso']", "click", btn=2)
-        b.click(".contextMenu button:contains('Download')")
-        self.waitDownloadFile("test.iso", 1500 * 1024 * 1024)
-
         # Selected view is saved in localStorage
         b.logout()
         self.login_and_go("/files")

--- a/test/check-application
+++ b/test/check-application
@@ -83,14 +83,12 @@ class TestFiles(testlib.MachineCase):
         b.set_input_text("#rename-item-input", f"{newname}")
         b.click("button.pf-m-primary")
 
-    def waitDownloadFile(self, filename: str, expected_size: int | None = None, content: str | None = None) -> None:
+    def waitDownloadFile(self, filename: str, expected_size: int, content: str | None = None) -> None:
         b = self.browser
         filepath = b.driver.download_dir / filename
 
         # Big downloads can take a while
-        testlib.wait(filepath.exists, tries=120)
-        if expected_size is not None:
-            testlib.wait(lambda: filepath.stat().st_size == expected_size)
+        testlib.wait(lambda: filepath.stat().st_size == expected_size, tries=120)
 
         if content is not None:
             self.assertEqual(filepath.read_text(), content)

--- a/test/check-application
+++ b/test/check-application
@@ -1007,10 +1007,12 @@ class TestFiles(testlib.MachineCase):
         b.wait_visible("[data-item='newdir2']")
         m.execute("rmdir /home/admin/newdir2")
 
+        # pixel test for directory context menu; resolution changes, so we need to re-open it for every layout
+        b.assert_pixels(".contextMenu", "folder-context-menu",
+                        layout_change_hook=lambda: self.open_context_menu("[data-item='newdir']"))
+
         # Rename folder from context menu
-        # HACK: context menu disappears in mobile mode
-        b.mouse("[data-item='newdir']", "contextmenu", x=0, y=0)
-        b.assert_pixels(".contextMenu", "folder-context-menu")
+        self.open_context_menu("[data-item='newdir']")
         b.click(".contextMenu button:contains('Rename')")
         b.set_input_text("#rename-item-input", "newdir1")
         b.click("button.pf-m-primary")
@@ -1066,9 +1068,12 @@ class TestFiles(testlib.MachineCase):
         b.click("button.pf-m-danger")
         b.wait_not_present("[data-item='newdir1']")
 
-        # HACK: context menu disappears in mobile mode
-        b.mouse("[data-item='newfile']", "contextmenu", x=0, y=0)
-        b.assert_pixels(".contextMenu", "file-context-menu")
+        # pixel test for file context menu; resolution changes, so we need to re-open it for every layout
+        b.assert_pixels(".contextMenu", "file-context-menu",
+                        layout_change_hook=lambda: self.open_context_menu("[data-item='newfile']"))
+
+        # Download file from context menu
+        self.open_context_menu("[data-item='newfile']")
         b.click(".contextMenu button:contains('Download')")
         size = int(self.stat('%s', '/home/admin/newfile'))
         self.waitDownloadFile("newfile", size, "some content\n")

--- a/test/check-application
+++ b/test/check-application
@@ -99,6 +99,16 @@ class TestFiles(testlib.MachineCase):
         b.click("#dropdown-menu")
         b.click(f".pf-v6-c-menu button:contains('{action}')")
 
+    def open_context_menu(self, selector: str) -> None:
+        b = self.browser
+        # close if it's already open; useful for assert_pixel layout hooks
+        if b.is_present(".contextMenu"):
+            b.click("body")
+            b.wait_not_present(".contextMenu")
+
+        b.mouse(selector, "click", btn=2)
+        b.wait_visible(".contextMenu")
+
     def open_folder_context_menu(self) -> None:
         # With BiDi on Firefox a click is by default in the "middle" of the
         # element while we want to open the current folder context and a
@@ -980,8 +990,8 @@ class TestFiles(testlib.MachineCase):
 
         b.click("button[aria-label='Display as a list']")
 
-        # Create folder from context menu, click in the middle to assert we can click everywhere.
-        b.mouse("#files-card-parent", "contextmenu", body_size[0] / 2, body_size[0] / 2)
+        # Create folder from context menu
+        self.open_folder_context_menu()
         b.click(".contextMenu button:contains('Create directory')")
         b.set_input_text("#create-directory-input", "newdir")
         b.click("button.pf-m-primary")
@@ -1009,7 +1019,7 @@ class TestFiles(testlib.MachineCase):
         # Edit permissions from context menu
         m.execute("useradd testuser")
         b.click("[data-item='newdir1']")
-        b.mouse("[data-item='newdir1']", "click", btn=2)
+        self.open_context_menu("[data-item='newdir1']")
         b.click(".contextMenu button:contains('Edit permissions')")
         b.select_from_dropdown("#edit-permissions-owner", "testuser")
         b.click("button.pf-m-primary")
@@ -1017,15 +1027,15 @@ class TestFiles(testlib.MachineCase):
 
         if not m.ws_container and self.system_before(329):
             # Open in terminal feature not supported before cockpit 329
-            b.mouse("[data-item='newdir1']", "click", btn=2)
+            self.open_context_menu("[data-item='newdir1']")
             b.wait_visible(".contextMenu button:contains('Delete')")
             b.wait_not_present(".contextMenu button:contains('Open in terminal')")
-            b.mouse("#files-card-parent", "contextmenu", body_size[0] / 2, body_size[0] / 2)
+            self.open_folder_context_menu()
             b.wait_visible(".contextMenu button:contains('Create directory')")
             b.wait_not_present(".contextMenu button:contains('Open in terminal')")
         else:
             # Open folder in terminal from context menu
-            b.mouse("[data-item='newdir1']", "click", btn=2)
+            self.open_context_menu("[data-item='newdir1']")
             b.click(".contextMenu button:contains('Open in terminal')")
             b.enter_page("/system/terminal")
             b.switch_to_top()
@@ -1035,7 +1045,7 @@ class TestFiles(testlib.MachineCase):
             b.enter_page("/files")
 
             # Open current dir in terminal from context menu
-            b.mouse("#files-card-parent", "contextmenu", body_size[0] / 2, body_size[0] / 2)
+            self.open_folder_context_menu()
             b.click(".contextMenu button:contains('Open in terminal')")
             b.enter_page("/system/terminal")
             b.switch_to_top()
@@ -1046,12 +1056,12 @@ class TestFiles(testlib.MachineCase):
 
         # Regular files should not have terminal feature
         m.execute("echo 'some content' > /home/admin/newfile")
-        b.mouse("[data-item='newfile']", "click", btn=2)
+        self.open_context_menu("[data-item='newfile']")
         b.wait_visible(".contextMenu button:contains('Delete')")
         b.wait_not_present(".contextMenu button:contains('Open in terminal')")
 
         # Delete folder from context menu
-        b.mouse("[data-item='newdir1']", "click", btn=2)
+        self.open_context_menu("[data-item='newdir1']")
         b.click(".contextMenu button:contains('Delete')")
         b.click("button.pf-m-danger")
         b.wait_not_present("[data-item='newdir1']")
@@ -1064,7 +1074,7 @@ class TestFiles(testlib.MachineCase):
         self.waitDownloadFile("newfile", size, "some content\n")
 
         # Delete button text should match item type: directory/file
-        b.mouse("[data-item='newfile']", "click", btn=2)
+        self.open_context_menu("[data-item='newfile']")
         b.click(".contextMenu button:contains('Delete')")
         b.click("button.pf-m-danger")
         b.wait_not_present("[data-item='newfile']")
@@ -1072,7 +1082,7 @@ class TestFiles(testlib.MachineCase):
         # The grid view also supports a contextmenu
         m.execute("touch /home/admin/testfile")
         b.click("button[aria-label='Display as a grid']")
-        b.mouse("[data-item='testfile']", "click", btn=2)
+        self.open_context_menu("[data-item='testfile']")
         b.wait_visible(".contextMenu button:contains('Delete')")
 
     def testDownload(self) -> None:
@@ -1085,14 +1095,14 @@ class TestFiles(testlib.MachineCase):
         # Big file downloads fine
         m.execute("truncate -s 1500M /home/admin/test.iso")
         b.wait_visible("[data-item='test.iso']")
-        b.mouse("[data-item='test.iso']", "click", btn=2)
+        self.open_context_menu("[data-item='test.iso']")
         b.click(".contextMenu button:contains('Download')")
         self.waitDownloadFile("test.iso", 1500 * 1024 * 1024)
 
         # non-latin1 file is fine
         m.execute("echo 'non-latin filename' > /home/admin/漢字")
         b.wait_visible("[data-item='漢字']")
-        b.mouse("[data-item='漢字']", "click", btn=2)
+        self.open_context_menu("[data-item='漢字']")
         b.click(".contextMenu button:contains('Download')")
         size = int(self.stat('%s', '/home/admin/漢字'))
         self.waitDownloadFile("漢字", size, "non-latin filename\n")
@@ -1317,8 +1327,7 @@ class TestFiles(testlib.MachineCase):
             b.select_from_dropdown("#edit-permissions-other-access", access)
 
         def open_permissions_dialog(filename: str) -> None:
-            b.wait_visible(f"[data-item='{filename}']")
-            b.mouse(f"[data-item='{filename}']", "click", btn=2)
+            self.open_context_menu(f"[data-item='{filename}']")
             b.click(".contextMenu button:contains('Edit permissions')")
             b.wait_in_text(".pf-v6-c-modal-box__title-text", filename)
 
@@ -1620,7 +1629,7 @@ class TestFiles(testlib.MachineCase):
         # Editing two files
         b.click("[data-item='filename1']")
         b.mouse("[data-item='filename2']", "click", ctrlKey=True)
-        b.mouse("[data-item='filename1']", "click", btn=2)
+        self.open_context_menu("[data-item='filename1']")
         b.click("button:contains('Edit permissions')")
 
         b.wait_text(".pf-v6-c-modal-box__title-text", "Permissions for 2 files")
@@ -1639,7 +1648,7 @@ class TestFiles(testlib.MachineCase):
             # HACK: the selected state contains a copy of files state so permissions information is not updated.
             b.mouse("[data-item='filename1']", "click", ctrlKey=True)
             b.mouse("[data-item='filename1']", "click", ctrlKey=True)
-            b.mouse("[data-item='filename1']", "click", btn=2)
+            self.open_context_menu("[data-item='filename1']")
             b.click("button:contains('Edit permissions')")
 
             b.wait_visible("#edit-permissions-owner-access")
@@ -1666,7 +1675,7 @@ class TestFiles(testlib.MachineCase):
 
         # No Edit permissions when selecting a folder and files
         b.mouse("[data-item='testdir']", "click", ctrlKey=True)
-        b.mouse("[data-item='filename1']", "click", btn=2)
+        self.open_context_menu("[data-item='filename1']")
         b.wait_visible("button:contains('Delete')")
         b.wait_not_present("button:contains('Edit permissions')")
 
@@ -1677,7 +1686,7 @@ class TestFiles(testlib.MachineCase):
         for i in range(3, 15):
             b.mouse(f"[data-item='filename{i}']", "click", ctrlKey=True)
 
-        b.mouse("[data-item='filename3']", "click", btn=2)
+        self.open_context_menu("[data-item='filename3']")
         b.click("button:contains('Edit permissions')")
 
         b.wait_text(".pf-v6-c-modal-box__title-text", "Permissions for 13 files")
@@ -1869,7 +1878,7 @@ class TestFiles(testlib.MachineCase):
         # Check context menu
         b.mouse("[data-item='file2']", "click", ctrlKey=True)
         b.wait_visible("[data-item='file2'].row-selected")
-        b.mouse("[data-item='file1']", "click", btn=2)
+        self.open_context_menu("[data-item='file1']")
         b.wait_in_text(".contextMenu li:nth-child(2) button", "Delete")
         b.click(".contextMenu button:contains('Delete')")
         b.wait_in_text("h1.pf-v6-c-modal-box__title", "Delete 2 items?")
@@ -3084,7 +3093,7 @@ class TestFiles(testlib.MachineCase):
         self.enter_files()
 
         def open_editor(file: str) -> None:
-            b.mouse(f"[data-item='{file}']", "click", btn=2)
+            self.open_context_menu(f"[data-item='{file}']")
             b.click(".contextMenu button:contains('Open text file')")
 
         def validate_content(file: str, content: str) -> None:
@@ -3104,13 +3113,13 @@ class TestFiles(testlib.MachineCase):
         """)
 
         # Don't allow opening big text files
-        b.mouse("[data-item='big.txt']", "click", btn=2)
+        self.open_context_menu("[data-item='big.txt']")
         b.wait_not_in_text(".contextMenu", "Open text file")
         b.click("#files-card-parent tbody")
         b.wait_not_present(".contextMenu")
 
         # A tarball cannot be edited
-        b.mouse("[data-item='archive.tar.gz']", "click", btn=2)
+        self.open_context_menu("[data-item='archive.tar.gz']")
         b.wait_not_in_text(".contextMenu", "Open text file")
         b.click("#files-card-parent tbody")
         b.wait_not_present(".contextMenu")
@@ -3358,7 +3367,7 @@ class TestFiles(testlib.MachineCase):
         b.wait_visible(f"[data-item='{test_directory}']")
 
         def create_symlink(filename: str) -> None:
-            b.mouse(f"[data-item='{filename}']", "click", btn=2)
+            self.open_context_menu(f"[data-item='{filename}']")
             b.click(".contextMenu button:contains('Create link')")
             b.wait_in_text(".pf-v6-c-modal-box__title-text", f"Create link to {filename}")
 


### PR DESCRIPTION
Re-open the context menu after each layout change in the pixel test.

This slightly changes the pixel tests due to the rounded corners.

----

[pixel diff](https://github.com/cockpit-project/pixel-test-reference/compare/e13f780f59b86b5615073b5938048872990d1a68..10952d73639cf24f9d960a8a0dbcf9d472792615)

Also fixes the [testDownload flake](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit-files&days=14&test=%2Ftest%2Fcheck-application+TestFiles.testDownload) and the [testBasic](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit-files&days=14&test=%2Ftest%2Fcheck-application+TestFiles.testBasic) as well.