### PR TITLE
package.json: Drop unused glob and jed dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "4.6.2",
     "gettext-parser": "8.0.0",
-    "glob": "11.0.3",
-    "jed": "1.1.1",
     "sizzle": "2.3.10",
     "stylelint": "16.23.1",
     "stylelint-config-recommended-scss": "16.0.0",


### PR DESCRIPTION
Obsolete with recent cockpit lib updates.