### PR TITLE
test: don't initialise a git repo

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -3,7 +3,6 @@ set -eux
 cd "${SOURCE}"
 
 # tests need cockpit's bots/ libraries and test infrastructure
-git init
 rm -f bots  # common local case: existing bots symlink
 make bots test/common
 


### PR DESCRIPTION
This makes -e .git always succeed since 08f2710ffcd05e4a07dc5. On testing farm this is reinitialized the existing Git repository, but in gating there is no git repository so `./tools/node-modules checkout` fails.

---

Fixes [Fedora dist-git tests](https://artifacts.dev.testing-farm.io/f7690030-960d-4f81-b515-5c4df2daeba9/) on [PR](https://src.fedoraproject.org/rpms/cockpit-files/pull-request/92)