### PR TITLE
test: stop making all centos images -stream

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -15,10 +15,6 @@ fi
 . /run/host/usr/lib/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 
-if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
-    TEST_OS="${TEST_OS}-stream"
-fi
-
 # Chromium sometimes gets OOM killed on testing farm
 export TEST_BROWSER=firefox
 


### PR DESCRIPTION
With centos-10-stream we renamed our image to centos-10 so this no longer matches. Since the following bots commit we now symlinks centos-9 to rhel-9 so we can drop the whole conditional.

https://github.com/cockpit-project/bots/commit/7d3c07f5cf805a9ef85ffbf93e144e1993fdfe68