### PR TITLE
Makefile: Use runtime-npm-modules.txt as bundle stamp file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ APPSTREAMFILE=org.cockpit_project.$(PACKAGE_NAME).metainfo.xml
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check for node_modules/
 NODE_MODULES_TEST=package-lock.json
-# one example file in dist/ from bundler to check if that already ran
-DIST_TEST=dist/manifest.json
+# build.js ran in non-watch mode
+DIST_TEST=runtime-npm-modules.txt
 # one example file in pkg/lib to check if it was already checked out
 COCKPIT_REPO_STAMP=pkg/lib/cockpit-po-plugin.js
 # common arguments for tar, mostly to make the generated tarballs reproducible
@@ -142,7 +142,7 @@ $(TARFILE): $(DIST_TEST) $(SPEC) packaging/arch/PKGBUILD packaging/debian/change
 	tar --xz $(TAR_ARGS) -cf $(TARFILE) --transform 's,^,$(RPM_NAME)/,' \
 		--exclude packaging/$(SPEC).in --exclude test/reference \
 		$$(git ls-files | grep -v node_modules) \
-		$(COCKPIT_REPO_FILES) $(NODE_MODULES_TEST) $(SPEC) \
+		$(COCKPIT_REPO_FILES) $(NODE_MODULES_TEST) $(DIST_TEST) $(SPEC) \
 		packaging/arch/PKGBUILD packaging/debian/changelog packaging/debian/copyright dist/
 
 $(NODE_CACHE): $(NODE_MODULES_TEST)


### PR DESCRIPTION
Commit e15a518fddad11f broke dependencies:

 1. Run `./build.js --watch`, and ^C it after it finished
 2. Run `make cockpit-files.spec` or `make vm` or similar.

Step 1 would generate dist/, but not runtime-npm-modules.txt (as that is expensive, and annoying in watch mode). So use the latter as a stronger dependency.

----

Spotted by @allisonkarlitskaya in https://github.com/cockpit-project/cockpit-podman/pull/2321#discussion_r2511228646