### PR TITLE
spec: Make node tarball Source1 unconditional

### DIFF
--- a/packaging/cockpit-files.spec.in
+++ b/packaging/cockpit-files.spec.in
@@ -10,9 +10,7 @@ License: LGPL-2.1-or-later
 %endif
 
 Source0: https://github.com/cockpit-project/%{name}/releases/download/%{version}/%{name}-%{version}.tar.xz
-%if %{defined rebuild_bundle}
 Source1: https://github.com/cockpit-project/%{name}/releases/download/%{version}/%{name}-node-%{version}.tar.xz
-%endif
 
 BuildArch: noarch
 BuildRequires: make


### PR DESCRIPTION
I originally made this conditional as it would be dead weight for CentOS/RHEL (where we can't/don't rebuild the bundle). But conditional sources are discouraged [1] and also seem to break packit downstream releases [2].

Thanks to Nikola Forró for the hint!

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/SourceURL/#_do_not_conditionalize_sources
[2] https://src.fedoraproject.org/rpms/cockpit-files/pull-request/97

---

Same as https://github.com/cockpit-project/cockpit-podman/pull/2344