### PR TITLE
spec: Adjust to shared node modules path in Fedora 44

### DIFF
--- a/packaging/cockpit-files.spec.in
+++ b/packaging/cockpit-files.spec.in
@@ -45,9 +45,9 @@ A filesystem browser for Cockpit
 %build
 %if %{defined rebuild_bundle}
 rm -rf dist
-# HACK: node module packaging is currently broken in Fedora, should be in
+# HACK: node module packaging is broken in Fedora ≤ 43; should be in
 # common location, not major version specific one
-NODE_ENV=production NODE_PATH=$(echo /usr/lib/node_modules_*) ./build.js
+NODE_ENV=production NODE_PATH=/usr/lib/node_modules:$(echo /usr/lib/node_modules_*) ./build.js
 %else
 # Use pre-built bundle on distributions without nodejs-esbuild
 %endif


### PR DESCRIPTION
The latest rawhide esbuild [1] got rebuilt against the updated nodejs packages which now implement the common module path [2] /usr/lib/node_modules. Set that as prefered search path. Keep the version specific ones for Fedora 42 and 43.

[1] https://koji.fedoraproject.org/koji/rpminfo?rpmID=45394723
[2] https://discussion.fedoraproject.org/t/f43-change-proposal-nodejs-node-modules-path-self-contained/157324