### PR TITLE
packaging: require /usr/bin/node as buildrequires for Fedora rawhidu

### DIFF
--- a/packaging/cockpit-files.spec.in
+++ b/packaging/cockpit-files.spec.in
@@ -23,6 +23,7 @@ BuildRequires:  libappstream-glib
 BuildRequires: gettext
 %if %{defined rebuild_bundle}
 BuildRequires: nodejs
+BuildRequires: %{_bindir}/node
 BuildRequires: nodejs-esbuild
 %endif
 


### PR DESCRIPTION
Depend on the binary as rawhide transitioned into providing `nodejs` via a `nodejs-bin`.

https://fedoraproject.org/wiki/Changes/NodejsAlternativesSystem