### PR TITLE
alert: Refactor parameters to object 

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -23,10 +23,17 @@ export interface ClipboardInfo {
     files: FolderFileInfo[];
 }
 
-interface FilesContextType {
-    addAlert: (title: string, variant: AlertVariant, key: string, detail?: string | React.ReactNode,
-               actionLinks?: React.ReactNode) => void,
-    removeAlert: (key: string) => void,
+export interface AlertInfo {
+    title: string;
+    variant: AlertVariant;
+    key?: string;
+    detail?: string | React.ReactNode;
+    actionLinks?: React.ReactNode;
+}
+
+export interface FilesContextType {
+    addAlert: (alert: AlertInfo) => void,
+    removeAlert: (key: AlertInfo["key"]) => void,
     cwdInfo: FileInfo | null,
 }
 
@@ -119,4 +126,9 @@ export function debug(...args: unknown[]) {
 
 export function testIsAppleDevice() {
     return /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+}
+
+export function uniqueId() {
+    const uint32 = window.crypto.getRandomValues(new Uint32Array(1))[0];
+    return uint32.toString(16);
 }

--- a/src/dialogs/copyPasteOwnership.tsx
+++ b/src/dialogs/copyPasteOwnership.tsx
@@ -22,7 +22,7 @@ import { useEvent, useInit } from 'hooks.ts';
 import { superuser } from 'superuser';
 
 import { useFilesContext } from '../common.ts';
-import type { ClipboardInfo, FolderFileInfo } from '../common.ts';
+import type { AlertInfo, ClipboardInfo, FolderFileInfo } from '../common.ts';
 import { get_owner_candidates } from '../ownership.tsx';
 
 const _ = cockpit.gettext;
@@ -30,7 +30,7 @@ const _ = cockpit.gettext;
 async function pasteAsOwner(clipboard: ClipboardInfo,
     dstPath: string,
     ownerStr: string,
-    addAlert: (title: string, variant: AlertVariant, key: string, detail?: string) => void) {
+    addAlert: (alert: AlertInfo) => void) {
     try {
         await cockpit.spawn([
             "cp",
@@ -50,7 +50,7 @@ async function pasteAsOwner(clipboard: ClipboardInfo,
         }
     } catch (err) {
         const e = err as cockpit.BasicError;
-        addAlert(_("Pasting failed"), AlertVariant.danger, `${new Date().getTime()}`, e.message);
+        addAlert({ title: _("Pasting failed"), variant: AlertVariant.danger, detail: e.message });
 
         // cleanup potentially copied files in case of "chown" fail
         try {

--- a/src/dialogs/create-file.tsx
+++ b/src/dialogs/create-file.tsx
@@ -25,7 +25,7 @@ import { useInit } from 'hooks';
 import { superuser } from 'superuser';
 
 import "./editor.css";
-import { checkFilename, useFilesContext } from '../common.ts';
+import { AlertInfo, checkFilename, useFilesContext } from '../common.ts';
 import { get_owner_candidates } from '../ownership.tsx';
 
 const _ = cockpit.gettext;
@@ -203,14 +203,17 @@ const CreateFileModal = ({ dialogResult, path } : {
 export async function show_create_file_dialog(
     dialogs: Dialogs,
     path: string,
-    addAlert: (title: string, variant: AlertVariant, key: string, detail?: string) => void
+    addAlert: (alert: AlertInfo) => void
 ) {
     if (!superuser.allowed) {
         try {
             await cockpit.spawn(["test", "-w", path]);
         } catch {
-            addAlert(_("Cannot create file in current directory"), AlertVariant.warning, "create-file",
-                     _("Permission denied"));
+            addAlert({
+                title: _("Cannot create file in current directory"),
+                variant: AlertVariant.warning,
+                detail: _("Permission denied")
+            });
             return;
         }
     }

--- a/src/files-breadcrumbs.tsx
+++ b/src/files-breadcrumbs.tsx
@@ -83,8 +83,11 @@ function BookmarkButton({ path }: { path: string }) {
             await cockpit.spawn(["mkdir", "-p", config_dir]);
         } catch (err) {
             const exc = err as cockpit.BasicError; // HACK: You can't easily type an error in typescript
-            addAlert(_("Unable to create bookmark directory"), AlertVariant.danger, "bookmark-error",
-                     exc.message);
+            addAlert({
+                title: _("Unable to create bookmark directory"),
+                variant: AlertVariant.danger,
+                detail: exc.message
+            });
             return;
         }
 
@@ -103,8 +106,11 @@ function BookmarkButton({ path }: { path: string }) {
             });
         } catch (err) {
             const exc = err as cockpit.BasicError; // HACK: You can't easily type an error in typescript
-            addAlert(_("Unable to save bookmark file"), AlertVariant.danger, "bookmark-error",
-                     exc.message);
+            addAlert({
+                title: _("Unable to save bookmark file"),
+                variant: AlertVariant.danger,
+                detail: exc.message
+            });
         }
     };
 

--- a/src/upload-button.tsx
+++ b/src/upload-button.tsx
@@ -26,7 +26,7 @@ import { superuser } from "superuser";
 import * as timeformat from "timeformat";
 import { fmt_to_fragments } from "utils";
 
-import { permissionShortStr, useFilesContext } from "./common.ts";
+import { permissionShortStr, uniqueId, useFilesContext } from "./common.ts";
 import type { FolderFileInfo } from "./common.ts";
 import { edit_permissions } from "./dialogs/permissions.tsx";
 import { UploadContext } from "./files-folder-view.tsx";
@@ -273,7 +273,11 @@ export const UploadButton = ({
                 } catch (exc) {
                     const err = exc as BasicError;
                     console.warn("Cannot set initial file permissions", err.toString());
-                    addAlert(_("Failed"), AlertVariant.warning, "upload", err.toString());
+                    addAlert({
+                        title: _("Failed"),
+                        variant: AlertVariant.warning,
+                        detail: err.toString()
+                    });
 
                     try {
                         await cockpit.file(destination, { superuser: "require" }).replace(null);
@@ -313,8 +317,11 @@ export const UploadButton = ({
                                             { superuser: "require" });
                     } catch (exc) {
                         console.warn("Unable to move file to final destination", exc);
-                        addAlert(_("Upload error"), AlertVariant.danger, "upload-error",
-                                 _("Unable to move uploaded file to final destination"));
+                        addAlert({
+                            title: _("Upload error"),
+                            variant: AlertVariant.danger,
+                            detail: _("Unable to move uploaded file to final destination")
+                        });
                         try {
                             await cockpit.file(destination, { superuser: "require" }).replace(null);
                         } catch (exc) {
@@ -334,10 +341,17 @@ export const UploadButton = ({
                     }
                 }
                 if (exc instanceof DOMException && exc.name === 'AbortError') {
-                    addAlert(_("Cancelled"), AlertVariant.warning, "upload",
-                             cockpit.format(_("Cancelled upload of $0"), file.name));
+                    addAlert({
+                        title: _("Cancelled"),
+                        variant: AlertVariant.warning,
+                        detail: cockpit.format(_("Cancelled upload of $0"), file.name)
+                    });
                 } else {
-                    addAlert(_("Upload error"), AlertVariant.danger, "upload-error", exc.toString());
+                    addAlert({
+                        title: _("Upload error"),
+                        variant: AlertVariant.danger,
+                        detail: exc.toString()
+                    });
                 }
                 cancelledUploads.push(file);
             } finally {
@@ -355,7 +369,7 @@ export const UploadButton = ({
         // If all uploads are cancelled, don't show an alert
         if (cancelledUploads.length !== toUploadFiles.length) {
             const title = cockpit.ngettext(_("File uploaded"), _("Files uploaded"), toUploadFiles.length);
-            const key = window.btoa(toUploadFiles.join(""));
+            const key = uniqueId();
             let description;
             let action;
 
@@ -390,7 +404,13 @@ export const UploadButton = ({
                 );
             }
 
-            addAlert(title, AlertVariant.success, key, description, action);
+            addAlert({
+                title,
+                key,
+                variant: AlertVariant.success,
+                detail: description,
+                actionLinks: action
+            });
         }
     }, [
         addAlert,


### PR DESCRIPTION
Within `addAlert()` we had it so the caller of the function determined
the key, but as the key is being used as a React key for rendering and
also when we want to remove the alert, this becomes finnicky and
frustrating to use.

Generating the key within the function itself fits better and allows us
to have a unique key that we know for sure is possible to be used when
rendering and removing alerts. However, we still need to allow the user
of the function to send in a custom key in case they have actions or
otherwise want to close the alert through their custom means. For
example, when uploading a file and user wants to change SELinux context
we bring up a modal from clicking the action and want to close the
alert when doing so.

For generating the key I've used `crypto.randomUUID()` for alerts and
made key parameter optional.

Fixes: https://github.com/cockpit-project/cockpit-files/issues/1288
See-also: https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>