### PR TITLE
Add editor shortcuts

### DIFF
--- a/src/dialogs/create-file.tsx
+++ b/src/dialogs/create-file.tsx
@@ -101,7 +101,7 @@ const CreateFileModal = ({ dialogResult, path } : {
         }
     };
 
-    const handleSave = async () => {
+    const handleSave = React.useCallback(async () => {
         cockpit.assert(filename, "filename undefined");
         const filename_valid = checkFilename(filename, cwdInfo?.entries || {}, undefined);
         if (filename_valid !== null) {
@@ -119,7 +119,22 @@ const CreateFileModal = ({ dialogResult, path } : {
         }
 
         dialogResult.resolve(full_path);
-    };
+    }, [filename, path, cwdInfo, dialogResult, initialText, owner]);
+
+    React.useEffect(() => {
+        const onKeyDown = function (event: KeyboardEvent) {
+            if ((event.ctrlKey || event.metaKey) && (event.key === "s" || event.key === "S")) {
+                event.preventDefault();
+                handleSave();
+            }
+        };
+
+        window.addEventListener('keydown', onKeyDown);
+
+        return () => {
+            window.removeEventListener('keydown', onKeyDown);
+        };
+    }, [handleSave]);
 
     if (superuser.allowed && owner === undefined)
         return null;

--- a/src/dialogs/editor.tsx
+++ b/src/dialogs/editor.tsx
@@ -160,6 +160,28 @@ export const EditFileModal = ({ dialogResult, editor } : {
         dialogResult.resolve();
     }, [editor, dialogResult]);
 
+    React.useEffect(() => {
+        const onKeyDown = promptDiscardChanges
+            ? function (event: KeyboardEvent) {
+                if (event.key === "Enter" || ((event.ctrlKey || event.metaKey) && ["s", "S"].includes(event.key))) {
+                    event.preventDefault();
+                    saveThenClose();
+                }
+            }
+            : function (event: KeyboardEvent) {
+                if ((event.ctrlKey || event.metaKey) && ["s", "S"].includes(event.key)) {
+                    event.preventDefault();
+                    editor.save();
+                }
+            };
+
+        window.addEventListener('keydown', onKeyDown);
+
+        return () => {
+            window.removeEventListener('keydown', onKeyDown);
+        };
+    }, [editor, promptDiscardChanges, dialogResult, saveThenClose]);
+
     const boldBasename = (<b className="ct-heading-font-weight">{state.basename}</b>);
     /* Translators: This is the title of a modal dialog.  $0 represents a filename. */
     let title = <>{fmt_to_fragments(state?.writable ? _("Edit $0") : _("View $0"), boldBasename)}</>;

--- a/src/dialogs/keyboardShortcutsHelp.tsx
+++ b/src/dialogs/keyboardShortcutsHelp.tsx
@@ -122,6 +122,21 @@ const KeyboardShortcutsHelp = ({ dialogResult } : { dialogResult: DialogResult<v
         ]
     ];
 
+    const editorShortcuts: Array<[React.JSX.Element, string, string]> = [
+        [
+            <kbd className="keystroke" key="save-file">
+                <kbd className="key">{ctrlString}</kbd> +
+                <kbd className="key" key="save">S</kbd>
+            </kbd>,
+            _("Save current file"),
+            "save-file",
+        ], [
+            <kbd className="key" key="close-editor">Esc</kbd>,
+            _("Close editor"),
+            "close-editor",
+        ]
+    ];
+
     return (
         <Modal
           position="top"
@@ -151,6 +166,16 @@ const KeyboardShortcutsHelp = ({ dialogResult } : { dialogResult: DialogResult<v
                           isFillColumns
                         >
                             {editShortcuts.map(toDescriptionListGroups)}
+                        </DescriptionList>
+                    </Content>
+                    <Content>
+                        <Content component={ContentVariants.h2}>{_("Editor")}</Content>
+                        <DescriptionList
+                          isHorizontal
+                          isFluid
+                          isFillColumns
+                        >
+                            {editorShortcuts.map(toDescriptionListGroups)}
                         </DescriptionList>
                     </Content>
                 </Flex>

--- a/test/check-application
+++ b/test/check-application
@@ -3090,7 +3090,7 @@ class TestFiles(testlib.MachineCase):
         def validate_content(file: str, content: str) -> None:
             open_editor(file)
             b.wait_val(".file-editor-modal textarea", content)
-            b.click(".file-editor-modal button.pf-m-link")
+            b.click(".file-editor-modal [data-ouia-component-id='cancel-save']")
             b.wait_not_present(".file-editor-modal")
 
             # validate on disk
@@ -3292,6 +3292,68 @@ class TestFiles(testlib.MachineCase):
         b.key("Escape")  # Escape for modal
         b.wait_not_present(".file-editor-modal")
 
+        # Ctrl-S on editor saves and keeps modal open
+        open_editor("notes.txt")
+        b.wait_val(".file-editor-modal textarea", "reset\n")
+        b.set_input_text(".file-editor-modal textarea", "")
+        b.wait_visible(".file-editor-modal.is-modified")
+        b.blur(".file-editor-modal textarea")  # remove focus from textarea
+        b.key("S", modifiers=["Control"])  # Save
+        b.wait_not_present(".file-editor-modal.is-modified")
+        b.click(".file-editor-modal [data-ouia-component-id='cancel-save']")
+        b.wait_not_present(".file-editor-modal")
+
+        validate_content("notes.txt", "")
+
+        # Meta-s on editor saves and keeps modal open
+        open_editor("notes.txt")
+        b.wait_val(".file-editor-modal textarea", "")
+        b.set_input_text(".file-editor-modal textarea", "reset")
+        b.wait_visible(".file-editor-modal.is-modified")
+        b.blur(".file-editor-modal textarea")  # remove focus from textarea
+        b.key("s", modifiers=["Meta"])  # Save
+        b.wait_not_present(".file-editor-modal.is-modified")
+        b.click(".file-editor-modal [data-ouia-component-id='cancel-save']")
+        b.wait_not_present(".file-editor-modal")
+
+        validate_content("notes.txt", "reset\n")
+
+        # Ctrl-S on confirmation dialog saves and closes modal
+        open_editor("notes.txt")
+        b.wait_val(".file-editor-modal textarea", "reset\n")
+        b.set_input_text(".file-editor-modal textarea", "")
+        b.blur(".file-editor-modal textarea")  # remove focus from textarea
+        b.key("Escape")  # Escape for modal
+        b.wait_visible("#file-editor-prompt-modal")
+        b.key("S", modifiers=["Control"])  # Save
+        b.wait_not_present(".file-editor-modal")
+
+        validate_content("notes.txt", "")
+
+        # Meta-S on confirmation dialog saves and closes modal
+        open_editor("notes.txt")
+        b.wait_val(".file-editor-modal textarea", "")
+        b.set_input_text(".file-editor-modal textarea", "reset")
+        b.blur(".file-editor-modal textarea")  # remove focus from textarea
+        b.key("Escape")  # Escape for modal
+        b.wait_visible("#file-editor-prompt-modal")
+        b.key("s", modifiers=["Meta"])  # Save
+        b.wait_not_present(".file-editor-modal")
+
+        validate_content("notes.txt", "reset\n")
+
+        # Enter on confirmation dialog saves and closes modal
+        open_editor("notes.txt")
+        b.wait_val(".file-editor-modal textarea", "reset\n")
+        b.set_input_text(".file-editor-modal textarea", "")
+        b.blur(".file-editor-modal textarea")  # remove focus from textarea
+        b.key("Escape")  # Escape for modal
+        b.wait_visible("#file-editor-prompt-modal")
+        b.key("Enter")  # Default on save
+        b.wait_not_present(".file-editor-modal")
+
+        validate_content("notes.txt", "")
+
         # As unprivileged user
         b.drop_superuser()
         self.wait_directory_changed("/home/admin/")
@@ -3400,6 +3462,26 @@ class TestFiles(testlib.MachineCase):
         b.wait_not_present(".pf-v6-c-modal-box")
         self.assert_owner("/home/admin/empty-file", "admin:admin")
         self.assertEqual(m.execute("cat /home/admin/empty-file"), "")
+
+        # Ctrl-S on editor saves and closes modal
+        self.open_folder_context_menu()
+        b.click(".contextMenu button:contains('Create file')")
+        b.set_input_text("#file-name", "ctrls.txt")
+        b.set_input_text(".file-create-modal textarea", "foo")
+        b.blur(".file-create-modal textarea")  # remove focus from textarea
+        b.key("S", modifiers=["Control"])  # Save
+        b.wait_not_present(".file-create-modal")
+        self.assertEqual(m.execute("cat /home/admin/ctrls.txt"), "foo")
+
+        # Meta-s on editor saves and closes modal
+        self.open_folder_context_menu()
+        b.click(".contextMenu button:contains('Create file')")
+        b.set_input_text("#file-name", "metas.txt")
+        b.set_input_text(".file-create-modal textarea", "foo")
+        b.blur(".file-create-modal textarea")  # remove focus from textarea
+        b.key("s", modifiers=["Meta"])  # Save
+        b.wait_not_present(".file-create-modal")
+        self.assertEqual(m.execute("cat /home/admin/ctrls.txt"), "foo")
 
         # Unable to create a file
         self.open_folder_context_menu()


### PR DESCRIPTION
This adds:
- `CTRL+S` to save
- Updates the shortcuts menu

I apologize if my code is not the best, my react skills are quite rusty

Rico