### PR TITLE
bookmarks: Toggle star icon if bookmarked

### DIFF
--- a/src/files-breadcrumbs.tsx
+++ b/src/files-breadcrumbs.tsx
@@ -14,7 +14,14 @@ import { MenuToggle, MenuToggleElement } from "@patternfly/react-core/dist/esm/c
 import { PageBreadcrumb, PageSection, } from "@patternfly/react-core/dist/esm/components/Page";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { Tooltip, TooltipPosition } from "@patternfly/react-core/dist/esm/components/Tooltip";
-import { CheckIcon, OutlinedHddIcon, PencilAltIcon, StarIcon, TimesIcon } from "@patternfly/react-icons";
+import {
+    CheckIcon,
+    OutlinedHddIcon,
+    OutlinedStarIcon,
+    PencilAltIcon,
+    StarIcon,
+    TimesIcon
+} from "@patternfly/react-icons";
 
 import cockpit from "cockpit";
 import { basename } from "cockpit-path";
@@ -125,12 +132,16 @@ function BookmarkButton({ path }: { path: string }) {
     };
 
     let actionText = null;
+    let isBookmarked = false;
     if (!defaultBookmarks.some(bkmark => bkmark.loc === path)) {
         if (bookmarks.includes(path)) {
+            isBookmarked = true;
             actionText = _("Remove from bookmarks");
         } else if (cwdInfo !== null) {
             actionText = _("Add to bookmarks");
         }
+    } else {
+        isBookmarked = true;
     }
 
     return (
@@ -147,7 +158,8 @@ function BookmarkButton({ path }: { path: string }) {
                   <MenuToggle
                     id="bookmark-btn"
                     variant="secondary"
-                    icon={<StarIcon />}
+                    aria-label={isBookmarked ? _("Bookmarked") : _("Not bookmarked")}
+                    icon={isBookmarked ? <StarIcon /> : <OutlinedStarIcon />}
                     ref={toggleRef}
                     onClick={() => setIsOpen(!isOpen)}
                     isExpanded={isOpen}

--- a/test/check-application
+++ b/test/check-application
@@ -2915,6 +2915,8 @@ class TestFiles(testlib.MachineCase):
             b.click("#bookmark-btn")
             b.wait_not_present(".pf-v6-c-menu .pf-v6-c-menu__list-item")
 
+        # Home directory shows icon as bookmarked
+        b.wait_visible('#bookmark-btn[aria-label="Bookmarked"]')
         b.click("#bookmark-btn")
         # There is only one menu item
         b.wait_in_text(".pf-v6-c-menu .pf-v6-c-menu__list-item", "Home")
@@ -2926,11 +2928,15 @@ class TestFiles(testlib.MachineCase):
 
         # Add a bookmark
         self.chdir('/etc')
+        b.wait_visible('#bookmark-btn[aria-label="Not bookmarked"]')
+        b.assert_pixels("#bookmark-btn", "bookmark-btn-unbookmarked")
         b.click("#bookmark-btn")
         b.click(".pf-v6-c-menu .pf-v6-c-menu__list-item button:contains(Add to bookmarks)")
         b.wait_not_present(".pf-v6-c-menu")
+        b.wait_visible('#bookmark-btn[aria-label="Bookmarked"]')
 
         assert_bookmark("/etc", exists=True)
+        b.assert_pixels("#bookmark-btn", "bookmark-btn-bookmarked")
 
         # Remove bookmark
         b.click("#bookmark-btn")


### PR DESCRIPTION
Changes the bookmark icon to show at a glance if current directory is
bookmarked or not. When it shows outline it is not bookmarked and when
filled it is either bookmarked or the home directory.

For accessibility an aria-label was added to show "Bookmarked" and
"Not bookmarked".

[Kooha-2026-05-26-15-08-28.webm](https://github.com/user-attachments/assets/37329fba-d7a6-4b21-bd87-053d43053c2c)

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
