### PR TITLE
fix two permissions dialog races

### DIFF
--- a/src/dialogs/permissions.tsx
+++ b/src/dialogs/permissions.tsx
@@ -241,7 +241,7 @@ const EditPermissionsModal = ({ dialogResult, items, path } : {
             val += 1;
         }
 
-        setMode((mode & mask) | (val << shift));
+        setMode(mode => (mode & mask) | (val << shift));
     }
 
     function setExecutableBits(shouldBeExecutable: boolean) {
@@ -249,9 +249,9 @@ const EditPermissionsModal = ({ dialogResult, items, path } : {
 
         // Strip / add executable bits
         if (shouldBeExecutable) {
-            setMode(mode | 0b001001001);
+            setMode(mode => mode | 0b001001001);
         } else {
-            setMode(mode & ~0b001001001);
+            setMode(mode => mode & ~0b001001001);
         }
     }
 

--- a/test/check-application
+++ b/test/check-application
@@ -1715,6 +1715,7 @@ class TestFiles(testlib.MachineCase):
         # A user cannot change ownership
         b.wait_not_in_text(".pf-v6-c-modal-box__body", "Ownership")
         b.click(".pf-v6-c-modal-box button.pf-m-primary")
+        b.wait_not_present(".pf-v6-c-modal-box")
         self.assertEqual(self.stat("%A", "/home/admin/adminfile"), "-rw-rw-rw-")
         check_perms_match('adminfile', '/home/admin')
         # Does not change ownership


### PR DESCRIPTION
One (theoretical) actual code fix and one (practical, observed on AWS) tests fix.