### PR TITLE
test: Allow installing updates from a vendor

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -9,7 +9,7 @@ cd "${0%/*}/../.."
 main_builds_repo="$(ls /etc/yum.repos.d/*cockpit*main-builds* 2>/dev/null || true)"
 if [ -n "$main_builds_repo" ]; then
     echo 'priority=0' >> "$main_builds_repo"
-    dnf distro-sync -y --repo 'copr*' cockpit-files
+    dnf distro-sync --setopt=allow_vendor_change=1 -y --repo 'copr*' cockpit-files
 fi
 
 # Show critical package versions


### PR DESCRIPTION
New DNF5 policy does not allow switching vendors if in our example a COPR repository offers a newer version of cockpit-files. We want to override this behaviour and in reverse dependency testing install the latest version of cockpit-files (provided by @cockpit/main-builds).

https://fedoraproject.org/wiki/Changes/DisableVendorChangeByDefault