### PR TITLE
permissions: Use a custom chmod utility

### DIFF
--- a/src/dialogs/permissions.tsx
+++ b/src/dialogs/permissions.tsx
@@ -32,6 +32,7 @@ import { fmt_to_fragments } from 'utils.tsx';
 import { inode_types } from '../common.ts';
 import type { FolderFileInfo } from '../common.ts';
 
+import py_chmod from './py-chmod.py';
 import read_selinux_context from './read-selinux.py';
 
 const _ = cockpit.gettext;
@@ -53,56 +54,6 @@ const OPTIONS_PERMISSIONS: Record<string, number> = {
     "read-only": 4,
     "read-write": 6,
 };
-
-// Convert the permissions mode to string based permissions to support
-// passing `+X` to chmod which cannot be combined with numeric mode.
-// Cockpit wants to pass `+X` for changing a folder and its contents, this only
-// makes folders executable and retains the executable bits on a file and
-// compared to `+x` does not make every file executable in a directory.
-function mode_to_args(mode: number) {
-    const offset_map: Record<number, string> = {
-        6: 'u',
-        3: 'g',
-        0: 'o',
-    };
-
-    const letter_map: Record<number, string> = {
-        4: 'r',
-        2: 'w',
-        1: 'X',
-    };
-
-    const chmod_args = [];
-    for (const offset_str of Object.keys(offset_map)) {
-        const offset = parseInt(offset_str, 10);
-        const single_mode = (mode >> offset) & 0o7;
-        let chmod_add = "";
-        let chmod_rem = "";
-
-        for (const digit_str of Object.keys(letter_map)) {
-            // An object's keys are automatically converted to a string
-            const digit = parseInt(digit_str, 10);
-            if ((single_mode & digit) === digit) {
-                chmod_add += letter_map[digit];
-            } else {
-                // Removal needs -x not -X
-                chmod_rem += letter_map[digit].toLowerCase();
-            }
-        }
-
-        if (chmod_add.length !== 0) {
-            chmod_add = "+" + chmod_add;
-        }
-
-        if (chmod_rem.length !== 0) {
-            chmod_rem = "-" + chmod_rem;
-        }
-
-        chmod_args.push(`${offset_map[offset]}${chmod_add}${chmod_rem}`);
-    }
-
-    return chmod_args.join(",");
-}
 
 const EditPermissionsModal = ({ dialogResult, items, path } : {
     dialogResult: DialogResult<void>,
@@ -167,8 +118,8 @@ const EditPermissionsModal = ({ dialogResult, items, path } : {
 
     const spawnEncloseFiles = async () => {
         try {
-            await cockpit.spawn(["chmod", "-R", "--", mode_to_args(mode), full_path],
-                                { superuser: "try", err: "message" });
+            await python.spawn(py_chmod, ["--recursive", mode.toString(8), full_path],
+                               { superuser: "try", err: "message" });
 
             await cockpit.spawn(["chown", "-R", "--no-dereference", "--", owner + ":" + group, full_path],
                                 { superuser: "try", err: "message" });
@@ -188,8 +139,8 @@ const EditPermissionsModal = ({ dialogResult, items, path } : {
 
         try {
             if (permissionChanged)
-                await cockpit.spawn(["chmod", "--", mode.toString(8), ...file_paths],
-                                    { superuser: "try", err: "message" });
+                await python.spawn(py_chmod, [mode.toString(8), ...file_paths],
+                                   { superuser: "try", err: "message" });
 
             if (ownerChanged)
                 await cockpit.spawn(["chown", "--no-dereference", "--", owner + ":" + group, ...file_paths],

--- a/src/dialogs/py-chmod.py
+++ b/src/dialogs/py-chmod.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import stat
+import sys
+
+recursive = sys.argv[1] == "--recursive"
+mode = sys.argv[2] if recursive else sys.argv[1]
+paths = sys.argv[3:] if recursive else sys.argv[2:]
+
+
+def chmod_nofollow(path: str, mode: int, dirfd: 'int | None' = None, *, capitalize_x: bool = False) -> int:
+    exit_code = 0
+
+    fd = os.open(path, os.O_PATH | os.O_NOFOLLOW, dir_fd=dirfd)
+    try:
+        st = os.fstat(fd)
+        if stat.S_ISLNK(st.st_mode):
+            return 0
+        effective_mode = mode
+        if capitalize_x and stat.S_ISREG(st.st_mode) and not (st.st_mode & 0o111):
+            effective_mode = mode & ~0o111
+        os.chmod(f"/proc/self/fd/{fd}", effective_mode)
+    except PermissionError:
+        sys.stderr.write(f"chmod: changing permissions of '{path}': Operation not permitted\n")
+        exit_code = 1
+    except FileNotFoundError:
+        pass
+    finally:
+        os.close(fd)
+
+    return exit_code
+
+
+def chmod_recursive(path: str, mode: int) -> int:
+    exit_code = chmod_nofollow(path, mode)
+    for _, dirnames, filenames, dirfd in os.fwalk(path):
+        for name in dirnames + filenames:
+            exit_status = chmod_nofollow(name, mode, dirfd, capitalize_x=True)
+            if exit_status != 0:
+                exit_code = exit_status
+
+    return exit_code
+
+
+parsed_mode = int(mode, 8)
+exit_code = 0
+for path in paths:
+    if recursive:
+        ret = chmod_recursive(path, parsed_mode)
+    else:
+        ret = chmod_nofollow(path, parsed_mode)
+    if ret != 0:
+        exit_code = ret
+sys.exit(exit_code)

--- a/src/dialogs/py-chmod.py.d.ts
+++ b/src/dialogs/py-chmod.py.d.ts
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+declare const content: string;
+export default content;


### PR DESCRIPTION
Our chmod invocations are susceptible to a "time of check to time of use" check where someone could replace a file you want to change permissions of with a symlink.

Coreutls 9.5 fixed this issue by supporting `--no-dereference` in chmod however RHEL 9.9/8.10 does not support it yet. Our own Python implementation skips symlinks in a race free manner.